### PR TITLE
new attribute interpreter for commands

### DIFF
--- a/.ci/gotenberg.yml
+++ b/.ci/gotenberg.yml
@@ -17,12 +17,15 @@ commands:
   # Unlike others commands' templates, you have access to FilesPaths instead of FilePath: it gathers all PDF files which should be merged.
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   
   conversions:
 
       # The command template: you have access to FilePath and ResultFilePath variables.
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      # The binary which will call the command.
+      interpreter: "/bin/sh -c"
       # Duration in seconds after which the command will be killed if it has not finished.
       timeout: 30
       # Files with the following extensions will be converted by the current command.
@@ -30,12 +33,14 @@ commands:
         - ".md"
 
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
 
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/broken-gotenberg.yml
+++ b/_tests/configurations/broken-gotenberg.yml
@@ -8,18 +8,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/duplicate-command-gotenberg.yml
+++ b/_tests/configurations/duplicate-command-gotenberg.yml
@@ -5,22 +5,27 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/gotenberg.yml
+++ b/_tests/configurations/gotenberg.yml
@@ -5,18 +5,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/merge-timeout-gotenberg.yml
+++ b/_tests/configurations/merge-timeout-gotenberg.yml
@@ -5,18 +5,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 0
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/timeout-gotenberg.yml
+++ b/_tests/configurations/timeout-gotenberg.yml
@@ -5,18 +5,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 0
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 0
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 0
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 0
       extensions:
         - ".doc"

--- a/_tests/configurations/wrong-command-template-gotenberg.yml
+++ b/_tests/configurations/wrong-command-template-gotenberg.yml
@@ -5,18 +5,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   conversions:
     - template: "markdown-pdf {{ FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/wrong-logging-formatter-gotenberg.yml
+++ b/_tests/configurations/wrong-logging-formatter-gotenberg.yml
@@ -5,18 +5,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/wrong-logging-level-gotenberg.yml
+++ b/_tests/configurations/wrong-logging-level-gotenberg.yml
@@ -5,18 +5,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/_tests/configurations/wrong-merge-command-template-gotenberg.yml
+++ b/_tests/configurations/wrong-merge-command-template-gotenberg.yml
@@ -5,18 +5,22 @@ logs:
 commands:
   merge:
     template: "pdftk {{ range $filePath := FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
+    interpreter: "/bin/sh -c"
     timeout: 30
   conversions:
     - template: "markdown-pdf {{ .FilePath }} -o {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".md"
     - template: "xvfb-run -e /dev/stdout wkhtmltopdf {{ .FilePath }} {{ .ResultFilePath }}"
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".html"
         - ".htm"
     - template: "unoconv --format pdf --output \"{{ .ResultFilePath }}\" \"{{ .FilePath }}\""
+      interpreter: "/bin/sh -c"
       timeout: 30
       extensions:
         - ".doc"

--- a/app/config/parser.go
+++ b/app/config/parser.go
@@ -24,7 +24,7 @@ func ParseFile(configurationFilePath string) error {
 	}
 
 	// handles merge command first...
-	cmd, err := NewCommand(fileConfig.Commands.Merge.Template, fileConfig.Commands.Merge.Timeout)
+	cmd, err := NewCommand(fileConfig.Commands.Merge.Template, fileConfig.Commands.Merge.Interpreter, fileConfig.Commands.Merge.Timeout)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func ParseFile(configurationFilePath string) error {
 
 	// ...then conversion commands!
 	for _, command := range fileConfig.Commands.Conversions {
-		cmd, err := NewCommand(command.Template, command.Timeout)
+		cmd, err := NewCommand(command.Template, command.Interpreter, command.Timeout)
 		if err != nil {
 			return err
 		}
@@ -64,15 +64,17 @@ type (
 
 	// mergeCommand gathers all data regarding the... merge command.
 	mergeCommand struct {
-		Template string `yaml:"template"`
-		Timeout  int    `yaml:"timeout"`
+		Template    string `yaml:"template"`
+		Interpreter string `yaml:"interpreter"`
+		Timeout     int    `yaml:"timeout"`
 	}
 
 	// conversionCommand gathers all data regarding a conversion command.
 	conversionCommand struct {
-		Template   string   `yaml:"template"`
-		Timeout    int      `yaml:"timeout"`
-		Extensions []string `yaml:"extensions"`
+		Template    string   `yaml:"template"`
+		Interpreter string   `yaml:"interpreter"`
+		Timeout     int      `yaml:"timeout"`
+		Extensions  []string `yaml:"extensions"`
 	}
 )
 

--- a/app/converter/process/process_test.go
+++ b/app/converter/process/process_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/thecodingmachine/gotenberg/app/config"
@@ -42,19 +43,19 @@ func TestRun(t *testing.T) {
 
 	// case 1: uses a simple command.
 	cmd = "echo Hello world"
-	if err := forest.run(cmd, 30); err != nil {
+	if err := forest.run(cmd, strings.Fields("/bin/sh -c"), 30); err != nil {
 		t.Errorf("Command '%s' should have worked", cmd)
 	}
 
 	// case 2: uses a simple command but with an unsuitable timeout.
 	cmd = "sleep 5"
-	if err := forest.run(cmd, 0); err == nil {
+	if err := forest.run(cmd, strings.Fields("/bin/sh -c"), 0); err == nil {
 		t.Errorf("Command '%s' should not have worked", cmd)
 	}
 
 	// case 3: uses a broken command.
 	cmd = "helloworld"
-	if err := forest.run(cmd, 30); err == nil {
+	if err := forest.run(cmd, strings.Fields("/bin/sh -c"), 30); err == nil {
 		t.Errorf("Command '%s' should not have worked", cmd)
 	}
 }


### PR DESCRIPTION
The new attribut `interpreter` allows user to specify a binary which will call the considered command.

Example:

```yaml
commands:
  merge:
    template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
    interpreter: "/bin/sh -c"
    timeout: 30
```

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`orbit run fmt`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`orbit run ci`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code