### PR TITLE
adding new attribute lock

### DIFF
--- a/.ci/gotenberg.yml
+++ b/.ci/gotenberg.yml
@@ -14,6 +14,11 @@ logs:
 # You may provide here your own implementation!
 commands:
 
+  # Some libraries like unoconv cannot perform concurrent conversions. That's why the API does only one conversion at a time.
+  # If your current implementation uses libraries which are able to perform concurrent conversions, you may
+  # change this value to false.
+  lock: true
+
   # Unlike others commands' templates, you have access to FilesPaths instead of FilePath: it gathers all PDF files which should be merged.
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"

--- a/_tests/configurations/broken-gotenberg.yml
+++ b/_tests/configurations/broken-gotenberg.yml
@@ -6,6 +6,7 @@ logs:
       ...
     }
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/duplicate-command-gotenberg.yml
+++ b/_tests/configurations/duplicate-command-gotenberg.yml
@@ -3,6 +3,7 @@ logs:
   level: "DEBUG"
   formatter: "text"
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/merge-timeout-gotenberg.yml
+++ b/_tests/configurations/merge-timeout-gotenberg.yml
@@ -3,6 +3,7 @@ logs:
   level: "DEBUG"
   formatter: "text"
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/no-lock-gotenberg.yml
+++ b/_tests/configurations/no-lock-gotenberg.yml
@@ -3,7 +3,7 @@ logs:
   level: "DEBUG"
   formatter: "text"
 commands:
-  lock: true
+  lock: false
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/timeout-gotenberg.yml
+++ b/_tests/configurations/timeout-gotenberg.yml
@@ -3,6 +3,7 @@ logs:
   level: "DEBUG"
   formatter: "text"
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/wrong-command-template-gotenberg.yml
+++ b/_tests/configurations/wrong-command-template-gotenberg.yml
@@ -3,6 +3,7 @@ logs:
   level: "DEBUG"
   formatter: "text"
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/wrong-logging-formatter-gotenberg.yml
+++ b/_tests/configurations/wrong-logging-formatter-gotenberg.yml
@@ -3,6 +3,7 @@ logs:
   level: "DEBUG"
   formatter: "DEBUG"
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/wrong-logging-level-gotenberg.yml
+++ b/_tests/configurations/wrong-logging-level-gotenberg.yml
@@ -3,6 +3,7 @@ logs:
   level: "text"
   formatter: "text"
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/_tests/configurations/wrong-merge-command-template-gotenberg.yml
+++ b/_tests/configurations/wrong-merge-command-template-gotenberg.yml
@@ -3,6 +3,7 @@ logs:
   level: "DEBUG"
   formatter: "text"
 commands:
+  lock: true
   merge:
     template: "pdftk {{ range $filePath := FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
     interpreter: "/bin/sh -c"

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -20,6 +20,7 @@ type (
 		port          string
 		logsLevel     logrus.Level
 		logsFormatter logrus.Formatter
+		lock          bool
 		// commands associates a file extension with a Command instance.
 		// Particular case: ".pdf" extension is used for the merge command.
 		commands map[string]*Command
@@ -124,6 +125,16 @@ func WithLogsFormatter(formatter string) error {
 // GetLogsFormatter returns the current logs formatter.
 func GetLogsFormatter() logrus.Formatter {
 	return config.logsFormatter
+}
+
+// WithLock sets the lock strategy.
+func WithLock(lock bool) {
+	config.lock = lock
+}
+
+// HasLock returns the current lock strategy.
+func HasLock() bool {
+	return config.lock
 }
 
 type interpreterEmptyError struct {

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -99,6 +99,24 @@ func TestGetLogsFormatter(t *testing.T) {
 	}
 }
 
+func TestWithLock(t *testing.T) {
+	lock := true
+	WithLock(lock)
+
+	if config.lock != lock {
+		t.Errorf("Configuration populated with a wrong lock strategy: got '%t' want '%t'", config.lock, lock)
+	}
+}
+
+func TestHasLock(t *testing.T) {
+	lock := true
+	config.lock = true
+
+	if HasLock() != lock {
+		t.Errorf("Configuration returned a wrong port: got '%t' want '%t'", HasLock(), lock)
+	}
+}
+
 func TestInterpreterEmptyError(t *testing.T) {
 	err := &interpreterEmptyError{"echo hello world"}
 	expected := fmt.Sprintf(interpreterEmptyErrorMessage, err.command)

--- a/app/config/parser.go
+++ b/app/config/parser.go
@@ -23,6 +23,8 @@ func ParseFile(configurationFilePath string) error {
 		return err
 	}
 
+	WithLock(fileConfig.Commands.Lock)
+
 	// handles merge command first...
 	cmd, err := NewCommand(fileConfig.Commands.Merge.Template, fileConfig.Commands.Merge.Interpreter, fileConfig.Commands.Merge.Timeout)
 	if err != nil {
@@ -57,6 +59,7 @@ type (
 			Formatter string `yaml:"formatter"`
 		} `yaml:"logs"`
 		Commands struct {
+			Lock        bool                 `yaml:"lock"`
 			Merge       *mergeCommand        `yaml:"merge"`
 			Conversions []*conversionCommand `yaml:"conversions,omitempty"`
 		} `yaml:"commands"`

--- a/app/converter/process/process.go
+++ b/app/converter/process/process.go
@@ -33,8 +33,12 @@ func (e *commandTimeoutError) Error() string {
 // run runs the given command. If timeout is reached or
 // something bad happened, returns an error.
 func (r *runner) run(command string, interpreter []string, timeout int) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	if config.HasLock() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+	} else {
+		logger.Warn("lock disabled")
+	}
 
 	binary := interpreter[0]
 	parameters := append(interpreter[1:], command)

--- a/app/converter/process/process_test.go
+++ b/app/converter/process/process_test.go
@@ -41,6 +41,8 @@ func TestCommandTimeoutError(t *testing.T) {
 func TestRun(t *testing.T) {
 	var cmd string
 
+	load("../../../_tests/configurations/gotenberg.yml")
+
 	// case 1: uses a simple command.
 	cmd = "echo Hello world"
 	if err := forest.run(cmd, strings.Fields("/bin/sh -c"), 30); err != nil {
@@ -57,6 +59,14 @@ func TestRun(t *testing.T) {
 	cmd = "helloworld"
 	if err := forest.run(cmd, strings.Fields("/bin/sh -c"), 30); err == nil {
 		t.Errorf("Command '%s' should not have worked", cmd)
+	}
+
+	load("../../../_tests/configurations/no-lock-gotenberg.yml")
+
+	// case 4: uses a configuration with a no lock strategy.
+	cmd = "echo Hello world"
+	if err := forest.run(cmd, strings.Fields("/bin/sh -c"), 30); err != nil {
+		t.Errorf("Command '%s' should have worked", cmd)
 	}
 }
 


### PR DESCRIPTION
The new attribute `lock` allows a user to perform concurrent conversions if its current implementation allows it.

Example:

```yaml
commands:
  lock: false
  merge:
    template: "pdftk {{ range $filePath := .FilesPaths }} {{ $filePath }} {{ end }} cat output {{ .ResultFilePath }}"
    interpreter: "/bin/sh -c"
    timeout: 30
```

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`orbit run fmt`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`orbit run ci`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code