### PR TITLE
Add a /ping endpoint

### DIFF
--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -67,6 +67,7 @@ func setup() *echo.Echo {
 			return nil
 		}
 	})
+	e.GET("/ping", func(c echo.Context) error { return nil })
 	e.POST("/merge", merge)
 	g := e.Group("/convert")
 	g.POST("/html", convertHTML)

--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPing(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	_ = e.NewContext(req, rec)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}


### PR DESCRIPTION
Hi!

I need to create a kubernetes pod with gotenberg and there is currently no easy way to set the liveness and readiness probs. In order to solve that issue I propose this ping endpoint which just return a 200 once the API is available.

It can be used to check the service liveness un docker-compose and is very useful for kubernetes (liveness and readiness probs).