### PR TITLE
Provide an endpoint to repair a damaged PDF

### DIFF
--- a/build/docs/content/12-repair.md
+++ b/build/docs/content/12-repair.md
@@ -1,0 +1,48 @@
+---
+title: PDF Repair
+---
+
+Gotenberg provides the endpoint `/repair` for trying to repair damaged PDF.
+
+It accepts `POST` requests with a `multipart/form-data` Content-Type.
+
+## Basic
+
+You may send a single PDF documents.
+
+### cURL
+
+```bash
+$ curl --request POST \
+    --url http://localhost:3000/repair \
+    --header 'Content-Type: multipart/form-data' \
+    --form files=@broken.pdf \
+    -o result.pdf
+```
+
+### Go
+
+```golang
+import "github.com/thecodingmachine/gotenberg/pkg"
+
+func main() {
+    c := &gotenberg.Client{Hostname: "http://localhost:3000"}
+    req, _ := gotenberg.NewPdfRepairRequest("broken.pdf", "broken.pdf")
+    dest := "result.pdf"
+    c.Store(req, dest)
+}
+```
+
+### PHP
+
+```php
+use TheCodingMachine\Gotenberg\Client;
+use TheCodingMachine\Gotenberg\DocumentFactory;
+use TheCodingMachine\Gotenberg\PdfRepairRequest;
+
+$client = new Client('http://localhost:3000', new \Http\Adapter\Guzzle6\Client());
+$file = DocumentFactory::makeFromPath('broken.pdf', 'broken.pdf');
+$request = new PdfRepairRequest($file);
+$dest = "result.pdf";
+$client->store($request, $dest);
+```

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -69,6 +69,7 @@ func setup() *echo.Echo {
 	})
 	e.GET("/ping", func(c echo.Context) error { return nil })
 	e.POST("/merge", merge)
+	e.POST("/repair", repairPDF)
 	g := e.Group("/convert")
 	g.POST("/html", convertHTML)
 	g.POST("/url", convertURL)

--- a/internal/app/api/repair.go
+++ b/internal/app/api/repair.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"errors"
+
+	"github.com/labstack/echo"
+	"github.com/thecodingmachine/gotenberg/internal/pkg/printer"
+)
+
+func repairPDF(c echo.Context) error {
+	r, err := newResource(c)
+	if err != nil {
+		return hijackErr(err, r)
+	}
+	ctx, cancel := newContext(r)
+	if cancel != nil {
+		defer cancel()
+	}
+	fpaths, err := r.filePaths([]string{".pdf"})
+	if err != nil {
+		return hijackErr(err, r)
+	}
+	if len(fpaths) == 0 {
+		return hijackErr(errors.New("no suitable PDF file to repair"), r)
+	}
+	p := &printer.Repair{Context: ctx, FilePaths: fpaths}
+	return print(c, p, r)
+}

--- a/internal/pkg/printer/repair.go
+++ b/internal/pkg/printer/repair.go
@@ -1,0 +1,25 @@
+package printer
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Repair a PDF’s Corrupted XREF Table and Stream Lengths (If Possible):
+type Repair struct {
+	Context   context.Context
+	FilePaths []string
+}
+
+func (r *Repair) Print(destination string) error {
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, r.FilePaths[0])
+	cmdArgs = append(cmdArgs, "output", destination)
+	cmd := exec.Command("pdftk", cmdArgs...)
+	return cmd.Run()
+}
+
+// Compile-time checks to ensure type implements desired interfaces.
+var (
+	_ = Printer(new(Repair))
+)

--- a/pkg/repair.go
+++ b/pkg/repair.go
@@ -1,0 +1,48 @@
+package gotenberg
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// PdfRepairRequest try to fix damaged PDF
+// with the Gotenberg API.
+type PdfRepairRequest struct {
+	filePaths []string
+	values    map[string]string
+}
+
+// NewPdfRepairRequest create PdfRepairRequest.
+func NewPdfRepairRequest(fpaths string) (*PdfRepairRequest, error) {
+	if !fileExists(fpath) {
+		return nil, fmt.Errorf("%s: file does not exist", fpath)
+	}
+
+	return &PdfRepairRequest{filePaths: fpath, values: make(map[string]string)}, nil
+}
+
+// SetWebhookURL sets webhookURL form field.
+func (r *PdfRepairRequest) SetWebhookURL(webhookURL string) {
+	r.values[webhookURL] = webhookURL
+}
+
+func (r *PdfRepairRequest) getPostURL() string {
+	return "/repair"
+}
+
+func (r *PdfRepairRequest) getFormValues() map[string]string {
+	return r.values
+}
+
+func (r *PdfRepairRequest) getFormFiles() map[string]string {
+	files := make(map[string]string)
+	for _, fpath := range r.filePaths {
+		files[filepath.Base(fpath)] = fpath
+	}
+	return files
+}
+
+// Compile-time checks to ensure type implements desired interfaces.
+var (
+	_ = Request(new(PdfRepairRequest))
+)


### PR DESCRIPTION
This PR fixes/implements the following **feature**

- [x] Repair damaged PDF

I got some PDF that was created with an old PDF writer. The XREF table has invalid stream offset.
As pdftk is already installed in Gotenberg, I found it handy to simply expose an additional endpoint, and pdftk does a wonderful job to quickly repair the PDF.

**Test plan (required)**

This is my first touch with Golang, so excuse me for any errors.
I have a damaged PDF but could not share it online. I can PM you if needed.

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] Have you updated the documentation (`make doc`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code