### PR TITLE
Fix google chrome env var error message

### DIFF
--- a/cmd/gotenberg/main.go
+++ b/cmd/gotenberg/main.go
@@ -37,7 +37,7 @@ func mustParseEnvVar() *api.Options {
 	}
 	if v, ok := os.LookupEnv(disableGoogleChromeEnvVar); ok {
 		if v != "1" && v != "0" {
-			notify.ErrPrint(fmt.Errorf("%s: wrong value: want \"0\" or \"1\" got %v", defaultWaitTimeoutEnvVar, v))
+			notify.ErrPrint(fmt.Errorf("%s: wrong value: want \"0\" or \"1\" got %v", disableGoogleChromeEnvVar, v))
 			os.Exit(1)
 		}
 		opts.EnableChromeEndpoints = v != "1"


### PR DESCRIPTION
**Summary**

This PR fixes a copy and paste error with the error message. I saw an 
```
error: DEFAULT_WAIT_TIMEOUT: wrong value: want "0" or "1" got true
```
When I should have seen 
```
error: DISABLE_GOOGLE_CHROME: wrong value: want "0" or "1" got true
```
when running gotenberg with `DISABLE_GOOGLE_CHROME=true`