### PR TITLE
Install pm2 via npm

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,4 +1,3 @@
-FROM thecodingmachine/gotenberg:3.2.0 AS hack
 FROM debian:9.5-slim
 
 # |--------------------------------------------------------------------------
@@ -20,19 +19,9 @@ RUN echo "deb http://httpredir.debian.org/debian/ stretch main contrib non-free"
 # | recovering. In our case: Chrome (headless) and Office (headless). 
 # |
 
-# Yep, this is dirty. The following script does not work anymore (see https://github.com/Unitech/pm2/issues/4127):
-#RUN curl -sL https://raw.githubusercontent.com/Unitech/pm2/master/packager/setup.deb.sh | bash -
-
-# Installing PM2 with Node.js and npm breaks something which prevents Google Chrome to work as expected.
-# So we just copy all PM2 related files from a previous version of Gotenberg.
-
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - &&\
-    apt-get install -y nodejs
-
-COPY --from=hack /usr/bin/pm2 /usr/bin/pm2
-COPY --from=hack /usr/share/pm2 /usr/share/pm2
-COPY --from=hack /etc/default/pm2 /etc/default/pm2
-COPY --from=hack /etc/systemd/system/pm2.service /etc/systemd/system/pm2.service
+    apt-get install -y nodejs &&\
+    npm install -g pm2
 
 # |--------------------------------------------------------------------------
 # | Chrome

--- a/internal/pkg/pm2/pm2.go
+++ b/internal/pkg/pm2/pm2.go
@@ -69,7 +69,7 @@ func (m *processManager) pm2(p Process, cmdName string) error {
 		p.name(),
 	}
 	if cmdName == "start" {
-		cmdArgs = append(cmdArgs, "--interpreter none", "--")
+		cmdArgs = append(cmdArgs, "--interpreter=none", "--")
 		cmdArgs = append(cmdArgs, p.args()...)
 	}
 	cmd := exec.Command(


### PR DESCRIPTION
As noted in the Dockerfile, the previous route to install pm2 was broken at
some point. As a result, pm2 related files are now being copied over from an
image created prior to the breakage.

This change now installs pm2 via npm, which is the recommended route for this.
A small adjustment had to be made in the processManager code; an
argument was being passed with a space in it. For reasons that I've not been
able to fully trace, this no longer works. It should be noted that passing
arguments in this way can result in undesirable behaviour - in this case I
believe "--interpreter none" was being passed as a single argument, rather than
"--interpreter", "none". I've adjusted this to use an equals - splitting into 2
separate strings works well too.

Refs #65