### PR TITLE
skip logging when healthcheck url is called

### DIFF
--- a/build/docs/content/03-environment-variables.md
+++ b/build/docs/content/03-environment-variables.md
@@ -31,3 +31,11 @@ It takes a string representation of a float as value (e.g `"2.5"` for 2.5 second
 
 > The default timeout may also be overridden per request thanks to the form field `waitTimeout`.
 > See the [timeout section](#timeout).
+
+## Disable logging on healthcheck
+
+By default, the API will add a log entry when the [healthcheck endpoint](#ping) is called.
+
+You may turn off this logging so as to avoid unnecessary entries in your logs with the environment variable `DISABLE_HEALTHCHECK_LOGGING`.
+
+This environment variable operates in the same manner as the `DISABLE_GOOGLE_CHROME` and `DISABLE_UNOCONV` variables operate in that it accepts the strings `"0"` or `"1"` as values. 

--- a/cmd/gotenberg/main.go
+++ b/cmd/gotenberg/main.go
@@ -23,6 +23,7 @@ const (
 	defaultWaitTimeoutEnvVar  = "DEFAULT_WAIT_TIMEOUT"
 	disableGoogleChromeEnvVar = "DISABLE_GOOGLE_CHROME"
 	disableUnoconvEnvVar      = "DISABLE_UNOCONV"
+	disablePingLoggingEnvVar  = "DISABLE_HEALTHCHECK_LOGGING"
 )
 
 func mustParseEnvVar() *api.Options {
@@ -48,6 +49,13 @@ func mustParseEnvVar() *api.Options {
 			os.Exit(1)
 		}
 		opts.EnableUnoconvEndpoints = v != "1"
+	}
+	if v, ok := os.LookupEnv(disablePingLoggingEnvVar); ok {
+		if v != "1" && v != "0" {
+			notify.ErrPrint(fmt.Errorf("%s: wrong value: want \"0\" or \"1\" got %v", disablePingLoggingEnvVar, v))
+			os.Exit(1)
+		}
+		opts.EnablePingLogging = v != "1"
 	}
 	return opts
 }

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -5,12 +5,15 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
+const pingEndpoint = "/ping"
+
 // Options allows to customize the behaviour
 // of the API.
 type Options struct {
 	DefaultWaitTimeout     float64
 	EnableChromeEndpoints  bool
 	EnableUnoconvEndpoints bool
+	EnablePingLogging      bool
 }
 
 // DefaultOptions returns default options.
@@ -19,6 +22,7 @@ func DefaultOptions() *Options {
 		DefaultWaitTimeout:     10,
 		EnableChromeEndpoints:  true,
 		EnableUnoconvEndpoints: true,
+		EnablePingLogging:      true,
 	}
 }
 
@@ -27,8 +31,8 @@ func New(opts *Options) *echo.Echo {
 	api := echo.New()
 	api.HideBanner = true
 	api.HidePort = true
-	api.Use(middleware.Logger())
-	api.GET("/ping", func(c echo.Context) error { return nil })
+	api.Use(loggerConfig(opts.EnablePingLogging))
+	api.GET(pingEndpoint, func(c echo.Context) error { return nil })
 	g := api.Group("/convert")
 	g.Use(handleContext(opts))
 	g.Use(handleError())
@@ -45,4 +49,19 @@ func New(opts *Options) *echo.Echo {
 		g.POST("/office", convertOffice)
 	}
 	return api
+}
+
+// If proper ENV given, skips logging when the ping endpoint is called;
+// otherwise logs
+func loggerConfig(enablePingLogging bool) echo.MiddlewareFunc {
+	if !enablePingLogging {
+		return middleware.LoggerWithConfig(middleware.LoggerConfig{
+			Skipper: func(c echo.Context) bool {
+				r := c.Request()
+				return r.URL.Path == pingEndpoint
+			},
+		})
+	}
+
+	return middleware.Logger()
 }


### PR DESCRIPTION
This PR closes #74.

I wasn't sure organizationally the best fit in terms of location for the skip function, so I added it into middleware.go with the other middleware functions. 

I also took the opportunity to add the `/ping` endpoint as a constant just to DRY it up a bit. Tested locally and it works as expected. 