### PR TITLE
Configure listen port via environment variable

### DIFF
--- a/build/docs/content/03-environment-variables.md
+++ b/build/docs/content/03-environment-variables.md
@@ -39,3 +39,11 @@ By default, the API will add a log entry when the [healthcheck endpoint](#ping) 
 You may turn off this logging so as to avoid unnecessary entries in your logs with the environment variable `DISABLE_HEALTHCHECK_LOGGING`.
 
 This environment variable operates in the same manner as the `DISABLE_GOOGLE_CHROME` and `DISABLE_UNOCONV` variables operate in that it accepts the strings `"0"` or `"1"` as values. 
+
+## Default listen port
+
+By default, the API will listen on port 3000. For most use cases this is perfectly fine, but at times there may be cases where you need to change this due to port conflicts.
+
+You may customize this port location with the environment variable `DEFAULT_LISTEN_PORT`. 
+
+This environment variable accepts any string that can be turned into a port number (e.g., the string `"0"` up to the string `"65535"`). 

--- a/build/docs/content/03-environment-variables.md
+++ b/build/docs/content/03-environment-variables.md
@@ -31,3 +31,11 @@ It takes a string representation of a float as value (e.g `"2.5"` for 2.5 second
 
 > The default timeout may also be overridden per request thanks to the form field `waitTimeout`.
 > See the [timeout section](#timeout).
+
+## Disable logging on healthcheck
+
+By default, the API will add a log entry when the [healthcheck endpoint](#ping) is called.
+
+You may turn off this logging so as to avoid unnecessary entries in your logs with the environment variable `DISABLE_HEALTHCHECK_LOGGING`.
+
+This environment variable operates in the same manner as the `DISABLE_GOOGLE_CHROME` and `DISABLE_UNOCONV` variables operate in that it accepts the strings `"0"` or `"1"` as values. 

--- a/cmd/gotenberg/main.go
+++ b/cmd/gotenberg/main.go
@@ -21,6 +21,7 @@ var version = "snapshot"
 
 const (
 	defaultWaitTimeoutEnvVar  = "DEFAULT_WAIT_TIMEOUT"
+	defaultListenPortEnvVar   = "DEFAULT_LISTEN_PORT"
 	disableGoogleChromeEnvVar = "DISABLE_GOOGLE_CHROME"
 	disableUnoconvEnvVar      = "DISABLE_UNOCONV"
 	disablePingLoggingEnvVar  = "DISABLE_HEALTHCHECK_LOGGING"
@@ -35,6 +36,18 @@ func mustParseEnvVar() *api.Options {
 			os.Exit(1)
 		}
 		opts.DefaultWaitTimeout = defaultWaitTimeout
+	}
+	if v, ok := os.LookupEnv(defaultListenPortEnvVar); ok {
+		defaultListener, err := strconv.ParseUint(os.Getenv(defaultListenPortEnvVar), 10, 64)
+		if err != nil {
+			notify.ErrPrint(fmt.Errorf("%s: wrong value: want uint got %v", defaultListenPortEnvVar, err))
+			os.Exit(1)
+		}
+		if defaultListener > 65535 {
+			notify.ErrPrint(fmt.Errorf("%s: wrong value: want uint < 65535; got %v", defaultListenPortEnvVar, defaultListener))
+			os.Exit(1)
+		}
+		opts.DefaultListenPort = v
 	}
 	if v, ok := os.LookupEnv(disableGoogleChromeEnvVar); ok {
 		if v != "1" && v != "0" {
@@ -78,9 +91,9 @@ func mustStartProcesses(opts *api.Options) []pm2.Process {
 	return processes
 }
 
-func mustStartAPI(srv *echo.Echo) {
-	notify.Print("http server started on port 3000")
-	if err := srv.Start(":3000"); err != nil {
+func mustStartAPI(srv *echo.Echo, port string) {
+	notify.Printf("http server started on port %v", port)
+	if err := srv.Start(fmt.Sprintf(":%v", port)); err != nil {
 		if err != http.ErrServerClosed {
 			notify.ErrPrint(err)
 			os.Exit(1)
@@ -118,7 +131,7 @@ func main() {
 	processes := mustStartProcesses(opts)
 	// run our API in a goroutine so that it doesn't block.s
 	go func() {
-		mustStartAPI(srv)
+		mustStartAPI(srv, opts.DefaultListenPort)
 	}()
 	quit := make(chan os.Signal, 1)
 	// we'll accept graceful shutdowns when quit via SIGINT (Ctrl+C)

--- a/cmd/gotenberg/main.go
+++ b/cmd/gotenberg/main.go
@@ -23,6 +23,7 @@ const (
 	defaultWaitTimeoutEnvVar  = "DEFAULT_WAIT_TIMEOUT"
 	disableGoogleChromeEnvVar = "DISABLE_GOOGLE_CHROME"
 	disableUnoconvEnvVar      = "DISABLE_UNOCONV"
+	disablePingLoggingEnvVar  = "DISABLE_HEALTHCHECK_LOGGING"
 )
 
 func mustParseEnvVar() *api.Options {
@@ -48,6 +49,13 @@ func mustParseEnvVar() *api.Options {
 			os.Exit(1)
 		}
 		opts.EnableUnoconvEndpoints = v != "1"
+	}
+	if v, ok := os.LookupEnv(disablePingLoggingEnvVar); ok {
+		if v != "1" && v != "0" {
+			notify.ErrPrint(fmt.Errorf("%s: wrong value: want \"0\" or \"1\" got %v", disablePingLoggingEnvVar, v))
+			os.Exit(1)
+		}
+		opts.EnablePingLogging = v != "1"
 	}
 	return opts
 }

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -11,6 +11,7 @@ const pingEndpoint = "/ping"
 // of the API.
 type Options struct {
 	DefaultWaitTimeout     float64
+	DefaultListenPort      string
 	EnableChromeEndpoints  bool
 	EnableUnoconvEndpoints bool
 	EnablePingLogging      bool
@@ -20,6 +21,7 @@ type Options struct {
 func DefaultOptions() *Options {
 	return &Options{
 		DefaultWaitTimeout:     10,
+		DefaultListenPort:      "3000",
 		EnableChromeEndpoints:  true,
 		EnableUnoconvEndpoints: true,
 		EnablePingLogging:      true,

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -5,12 +5,15 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
+const pingEndpoint = "/ping"
+
 // Options allows to customize the behaviour
 // of the API.
 type Options struct {
 	DefaultWaitTimeout     float64
 	EnableChromeEndpoints  bool
 	EnableUnoconvEndpoints bool
+	EnablePingLogging      bool
 }
 
 // DefaultOptions returns default options.
@@ -19,6 +22,7 @@ func DefaultOptions() *Options {
 		DefaultWaitTimeout:     10,
 		EnableChromeEndpoints:  true,
 		EnableUnoconvEndpoints: true,
+		EnablePingLogging:      true,
 	}
 }
 
@@ -27,8 +31,8 @@ func New(opts *Options) *echo.Echo {
 	api := echo.New()
 	api.HideBanner = true
 	api.HidePort = true
-	api.Use(middleware.Logger())
-	api.GET("/ping", func(c echo.Context) error { return nil })
+	api.Use(loggerConfig(opts.EnablePingLogging))
+	api.GET(pingEndpoint, func(c echo.Context) error { return nil })
 	g := api.Group("/convert")
 	g.Use(handleContext(opts))
 	g.Use(handleError())
@@ -45,4 +49,19 @@ func New(opts *Options) *echo.Echo {
 		g.POST("/office", convertOffice)
 	}
 	return api
+}
+
+// If proper ENV given, skips logging when the ping endpoint is called;
+// otherwise logs
+func loggerConfig(enablePingLogging bool) echo.MiddlewareFunc {
+	if !enablePingLogging {
+		return middleware.LoggerWithConfig(middleware.LoggerConfig{
+			Skipper: func(c echo.Context) bool {
+				r := c.Request()
+				return r.URL.Path == pingEndpoint
+			},
+		})
+	}
+
+	return middleware.Logger()
 }


### PR DESCRIPTION
This PR adds the ability to configure the port which gotenberg will listen on. Per discussion on #75 I've tried to keep to the environment variable paradigm outlined.

Although I've based this branch off the work on #75, it would be easy enough to separate them out more formally. 