### PR TITLE
Inconsistent text rendering in headless mode

### DIFF
--- a/internal/pkg/pm2/chrome.go
+++ b/internal/pkg/pm2/chrome.go
@@ -35,6 +35,7 @@ func (p *chrome) args() []string {
 	return []string{
 		"--no-sandbox",
 		"--headless",
+		"--font-render-hinting=medium",
 		"--remote-debugging-port=9222",
 		"--disable-gpu",
 		"--disable-translate",


### PR DESCRIPTION
This pull request is about adding additional argument for headless Chrome: **--font-render-hinting medium**, which is required for consistent font rendering. See [this issue](https://github.com/GoogleChrome/puppeteer/issues/2410)

Fonts differs in real Chrome from the ones in generated PDF, unless this option is provided