### PR TITLE
Add ENABLE_DEBUG_MODE config

### DIFF
--- a/cmd/gotenberg/main.go
+++ b/cmd/gotenberg/main.go
@@ -76,7 +76,7 @@ func mustParseEnvVar() *api.Options {
 			notify.ErrPrint(fmt.Errorf("%s: wrong value: want \"0\" or \"1\" got %v", enableDebugModeEnvVar, v))
 			os.Exit(1)
 		}
-		opts.EnableDebugMode = v != "1"
+		opts.EnableDebugMode = v == "1"
 	}
 	return opts
 }

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -14,6 +14,7 @@ type Options struct {
 	EnableChromeEndpoints    bool
 	EnableUnoconvEndpoints   bool
 	EnableHealthcheckLogging bool
+	EnableDebugMode          bool
 }
 
 // DefaultOptions returns default options.
@@ -24,6 +25,7 @@ func DefaultOptions() *Options {
 		EnableChromeEndpoints:    true,
 		EnableUnoconvEndpoints:   true,
 		EnableHealthcheckLogging: true,
+		EnableDebugMode:          false,
 	}
 }
 


### PR DESCRIPTION
Related to issue https://github.com/thecodingmachine/gotenberg/issues/113

Adding a new environment variable `ENABLE_DEBUG_MODE`, to activate 'Debug level' log.