### PR TITLE
Add basic authentication

### DIFF
--- a/build/docs/content/03-environment-variables.md
+++ b/build/docs/content/03-environment-variables.md
@@ -23,6 +23,16 @@ You may customize this value with the environment variable `DEFAULT_LISTEN_PORT`
 
 This environment variable accepts any string that can be turned into a port number.
 
+## Enable authentication
+
+In order protect the API exposed by Gotenberg, you can use the `ENABLE_AUTH` environment
+variable and set your desired username and password on `AUTH_USERNAME` and `AUTH_PASSWORD`.
+
+The `ENABLE_AUTH` environment variable takes the strings `"0"` or `"1"` as value
+where `1` means `true`
+
+> This configuration enables Basic HTTP Authentication on all HTTP endpoints.
+
 ## Disable Google Chrome
 
 In order to save some resources, the Gotenberg image accepts the environment variable `DISABLE_GOOGLE_CHROME`

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -10,8 +10,8 @@ FROM thecodingmachine/gotenberg:workspace AS workspace
 ARG VERSION
 
 ENV GOOS=linux \
-    GOARCH=amd64 \
-    CGO_ENABLED=0
+  GOARCH=amd64 \
+  CGO_ENABLED=0
 
 # Define our workding outside of $GOPATH (we're using go modules).
 WORKDIR /gotenberg/package
@@ -20,7 +20,7 @@ WORKDIR /gotenberg/package
 COPY go.mod go.sum ./
 
 RUN go mod download &&\
-    go mod verify
+  go mod verify
 
 # Copy our source code.
 COPY internal ./internal
@@ -42,9 +42,9 @@ LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>"
 
 ARG TINI_VERSION
 
-ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT [ "/tini", "--" ]
+ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static /usr/local/bin/tini
+RUN chmod +x /usr/local/bin/tini
+ENTRYPOINT [ "tini", "--" ]
 
 # |--------------------------------------------------------------------------
 # | Final touch

--- a/docs/index.html
+++ b/docs/index.html
@@ -249,6 +249,20 @@ about what’s going on.</p>
 
 <p>This environment variable accepts any string that can be turned into a port number.</p>
 
+<h2 class="Heading"><a class="Anchor" aria-hidden="true" id="environment_variables.enable_authentication" href="#environment_variables.enable_authentication">
+	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+</a>Enable authentication</h2>
+
+<p>In order protect the API exposed by Gotenberg, you can use the <code>ENABLE_AUTH</code> environment
+variable and set your desired username and password on <code>AUTH_USERNAME</code> and <code>AUTH_PASSWORD</code>.</p>
+
+<p>The <code>ENABLE_AUTH</code> environment variable takes the strings <code>&#34;0&#34;</code> or <code>&#34;1&#34;</code> as value
+where <code>1</code> means <code>true</code></p>
+
+<blockquote>
+<p>This configuration enables Basic HTTP Authentication on all HTTP endpoints.</p>
+</blockquote>
+
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="environment_variables.disable_google_chrome" href="#environment_variables.disable_google_chrome">
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>Disable Google Chrome</h2>

--- a/internal/app/xhttp/xhttp.go
+++ b/internal/app/xhttp/xhttp.go
@@ -12,7 +12,7 @@ func New(config conf.Config) *echo.Echo {
 	srv.HideBanner = true
 	srv.HidePort = true
 
-	if (config.EnableAuthentication()) {
+	if config.EnableAuthentication() {
 		srv.Use(middleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
 			if username == config.AuthenticationUsername() && password == config.AuthenticationPassword() {
 				return true, nil

--- a/internal/app/xhttp/xhttp_test.go
+++ b/internal/app/xhttp/xhttp_test.go
@@ -22,6 +22,24 @@ func TestNonExistingEndpoint(t *testing.T) {
 	test.AssertStatusCode(t, http.StatusNotFound, srv, req)
 }
 
+func TestHttpAuthentication(t *testing.T) {
+	os.Setenv(conf.EnableAuthEnvVar, "1")
+	os.Setenv(conf.AuthUsernameEnvVar, "foo")
+	os.Setenv(conf.AuthPasswordEnvVar, "bar")
+	config, err := conf.FromEnv()
+	assert.Nil(t, err)
+	srv := New(config)
+	// "/ping" endpoint should return 401 without auth.
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	test.AssertStatusCode(t, http.StatusUnauthorized, srv, req)
+	// "/ping" endpoint should return 200 with auth.
+	req = httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
+	test.AssertStatusCode(t, http.StatusOK, srv, req)
+
+	os.Setenv(conf.EnableAuthEnvVar, "0")
+}
+
 func TestDisableChromeEndpoints(t *testing.T) {
 	os.Setenv(conf.DisableGoogleChromeEnvVar, "1")
 	config, err := conf.FromEnv()

--- a/internal/pkg/conf/conf.go
+++ b/internal/pkg/conf/conf.go
@@ -37,6 +37,15 @@ const (
 	// DefaultGoogleChromeRpccBufferSizeEnvVar contains the name
 	// of the environment variable "DEFAULT_GOOGLE_CHROME_RPCC_BUFFER_SIZE".
 	DefaultGoogleChromeRpccBufferSizeEnvVar string = "DEFAULT_GOOGLE_CHROME_RPCC_BUFFER_SIZE"
+	// EnableAuthEnvVar contains the name
+	// of the environment variable "ENABLE_AUTH".
+	EnableAuthEnvVar string = "ENABLE_AUTH"
+	// AuthUsernameEnvVar contains the name
+	// of the environment variable "AUTH_USERNAME".
+	AuthUsernameEnvVar string = "AUTH_USERNAME"
+	// AuthPasswordEnvVar contains the name
+	// of the environment variable "ENABLE_AUTH".
+	AuthPasswordEnvVar string = "AUTH_PASSWORD"
 )
 
 // Config contains the application
@@ -50,6 +59,9 @@ type Config struct {
 	defaultListenPort                 int64
 	disableGoogleChrome               bool
 	disableUnoconv                    bool
+	enableAuthentication              bool
+	authenticationUsername            string
+	authenticationPassword            string
 	logLevel                          xlog.Level
 	maximumGoogleChromeRpccBufferSize int64
 	defaultGoogleChromeRpccBufferSize int64
@@ -70,6 +82,9 @@ func DefaultConfig() Config {
 		logLevel:                          xlog.InfoLevel,
 		maximumGoogleChromeRpccBufferSize: 104857600, // ~100 MB
 		defaultGoogleChromeRpccBufferSize: 1048576,   // 1 MB
+		enableAuthentication:              false,
+		authenticationUsername:            "",
+		authenticationPassword:            "",
 	}
 }
 
@@ -173,6 +188,30 @@ func FromEnv() (Config, error) {
 		if err != nil {
 			return c, err
 		}
+		enableAuthentication, err := xassert.BoolFromEnv(
+			EnableAuthEnvVar,
+			c.enableAuthentication,
+		)
+		c.enableAuthentication = enableAuthentication
+		if err != nil {
+			return c, err
+		}
+		authenticationUsername, err := xassert.StringFromEnv(
+			AuthUsernameEnvVar,
+			c.authenticationUsername,
+		)
+		c.authenticationUsername = authenticationUsername
+		if err != nil {
+			return c, err
+		}
+		authenticationPassword, err := xassert.StringFromEnv(
+			AuthUsernameEnvVar,
+			c.authenticationPassword,
+		)
+		c.authenticationPassword = authenticationPassword
+		if err != nil {
+			return c, err
+		}
 		return c, nil
 	}
 	result, err := resolver()
@@ -252,4 +291,22 @@ func (c Config) MaximumGoogleChromeRpccBufferSize() int64 {
 //  Google Chrome rpcc buffer size from the configuration.
 func (c Config) DefaultGoogleChromeRpccBufferSize() int64 {
 	return c.defaultGoogleChromeRpccBufferSize
+}
+
+// EnableAuthentication returns the bool from
+// the configuration.
+func (c Config) EnableAuthentication() bool {
+	return c.enableAuthentication
+}
+
+// AuthenticationUsername returns the string from
+// the configuration.
+func (c Config) AuthenticationUsername() string {
+	return c.authenticationUsername
+}
+
+// AuthenticationPassword returns the string from
+// the configuration.
+func (c Config) AuthenticationPassword() string {
+	return c.authenticationPassword
 }

--- a/internal/pkg/conf/conf.go
+++ b/internal/pkg/conf/conf.go
@@ -205,7 +205,7 @@ func FromEnv() (Config, error) {
 			return c, err
 		}
 		authenticationPassword, err := xassert.StringFromEnv(
-			AuthUsernameEnvVar,
+			AuthPasswordEnvVar,
 			c.authenticationPassword,
 		)
 		c.authenticationPassword = authenticationPassword

--- a/internal/pkg/conf/conf_test.go
+++ b/internal/pkg/conf/conf_test.go
@@ -224,6 +224,78 @@ func TestDefaultListenPortFromEnv(t *testing.T) {
 	os.Unsetenv(DefaultListenPortEnvVar)
 }
 
+func TestEnableAuthenticationFromEnv(t *testing.T) {
+	var (
+		expected Config
+		result   Config
+		err      error
+	)
+	// ENABLE_AUTH correctly set.
+	os.Setenv(EnableAuthEnvVar, "1")
+	expected = DefaultConfig()
+	expected.enableAuthentication = true
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(EnableAuthEnvVar)
+	os.Setenv(EnableAuthEnvVar, "0")
+	expected = DefaultConfig()
+	expected.enableAuthentication = false
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(EnableAuthEnvVar)
+	// DISABLE_GOOGLE_CHROME wrongly set.
+	os.Setenv(EnableAuthEnvVar, "foo")
+	expected = DefaultConfig()
+	result, err = FromEnv()
+	test.AssertError(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(EnableAuthEnvVar)
+}
+
+func TestAuthUsernameFromEnv(t *testing.T) {
+	var (
+		expected Config
+		result   Config
+		err      error
+	)
+	// AUTH_USERNAME correctly set.
+	os.Setenv(AuthUsernameEnvVar, "foo")
+	expected = DefaultConfig()
+	expected.authenticationUsername = "foo"
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(AuthUsernameEnvVar)
+	expected = DefaultConfig()
+	expected.authenticationUsername = ""
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestAuthPasswordFromEnv(t *testing.T) {
+	var (
+		expected Config
+		result   Config
+		err      error
+	)
+	// AUTH_PASSWORD correctly set.
+	os.Setenv(AuthPasswordEnvVar, "foo")
+	expected = DefaultConfig()
+	expected.authenticationPassword = "foo"
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(AuthPasswordEnvVar)
+	expected = DefaultConfig()
+	expected.authenticationPassword = ""
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
 func TestDisableGoogleChromeFromEnv(t *testing.T) {
 	var (
 		expected Config
@@ -365,6 +437,9 @@ func TestGetters(t *testing.T) {
 	assert.Equal(t, result.defaultWaitTimeout, result.DefaultWaitTimeout())
 	assert.Equal(t, result.defaultWebhookURLTimeout, result.DefaultWebhookURLTimeout())
 	assert.Equal(t, result.defaultListenPort, result.DefaultListenPort())
+	assert.Equal(t, result.enableAuthentication, result.EnableAuthentication())
+	assert.Equal(t, result.authenticationUsername, result.AuthenticationUsername())
+	assert.Equal(t, result.authenticationPassword, result.AuthenticationPassword())
 	assert.Equal(t, result.disableGoogleChrome, result.DisableGoogleChrome())
 	assert.Equal(t, result.disableUnoconv, result.DisableUnoconv())
 	assert.Equal(t, result.logLevel, result.LogLevel())

--- a/internal/pkg/conf/conf_test.go
+++ b/internal/pkg/conf/conf_test.go
@@ -245,7 +245,7 @@ func TestEnableAuthenticationFromEnv(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
 	os.Unsetenv(EnableAuthEnvVar)
-	// DISABLE_GOOGLE_CHROME wrongly set.
+	// ENABLE_AUTH wrongly set.
 	os.Setenv(EnableAuthEnvVar, "foo")
 	expected = DefaultConfig()
 	result, err = FromEnv()


### PR DESCRIPTION
**Summary**

This MR adds some changes we have been using internally, in order to add HTTP Basic authentication out-of-the-box.

We know that project's idea about this is that authentication should be provided by external software, but this can be useful in some scenarios, like running on Google Cloud Run.

This PR fixes/implements the following **features**

* [x] HTTP Basic authentication

The main motivation is, as explained above, allowing the container to run standalone in a serverless environment like the ones provided on AWS or GCP.

**Test plan (required)**

I have added tests that cover the functionality and this behaviour is configurable by using environment variables.

**Closing issues**

It does not close, but can help to the people watching [this issue](https://github.com/thecodingmachine/gotenberg/issues/90)

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] Have you updated the documentation (`make doc`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
