### PR TITLE
Fix container initialization in Google Cloud Run

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -42,7 +42,7 @@ LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>"
 
 ARG TINI_VERSION
 
-ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
+ADD --chown=gotenberg https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT [ "/tini", "--" ]
 


### PR DESCRIPTION
**Summary**

This PR fixes the issue where containers fail to start in Google Cloud Run (and potentially other cloud environments) due to a permission error on container initialization.

**Test plan (required)**

N/A

**Closing issues**

Fixes #90
