### PR TITLE
Use statically linked version of tini

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -42,7 +42,7 @@ LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>"
 
 ARG TINI_VERSION
 
-ADD --chown=gotenberg https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
+ADD --chown=gotenberg https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static /tini
 RUN chmod +x /tini
 ENTRYPOINT [ "/tini", "--" ]
 


### PR DESCRIPTION
**Summary**

This MR includes a small change to the package docke image to use an statically linked version of tini, so no issues related to updated libraries should arise in the future.

This PR fixes/implements the following **bugs/features**

* [x] More stable tini version

**Test plan (required)**

Building the image and checking that it starts succesfully.

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] Have you updated the documentation (`make doc`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
