### PR TITLE
Fixing documentation typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -155,7 +155,7 @@
 </span><span class="w">
 </span><span class="w"></span>services<span class="p">:</span><span class="w">
 </span><span class="w">
-</span><span class="w">  </span><span class="c"># your others services</span><span class="w">
+</span><span class="w">  </span><span class="c"># your other services</span><span class="w">
 </span><span class="w">
 </span><span class="w">  </span>gotenberg<span class="p">:</span><span class="w">
 </span><span class="w">    </span>image<span class="p">:</span><span class="w"> </span>thecodingmachine/gotenberg<span class="p">:</span><span class="m">6</span><span class="w">
@@ -549,7 +549,7 @@ $client-&gt;store($request, $dest);
 <p>The only requirement is to make sure that their paths
 are on the same level as the <code>index.html</code> file.</p>
 
-<p>In others words, this will work:</p>
+<p>In other words, this will work:</p>
 
 <pre class="chroma"><span class="cp">&lt;!doctype html&gt;</span>
 <span class="p">&lt;</span><span class="nt">html</span> <span class="na">lang</span><span class="o">=</span><span class="s">&#34;en&#34;</span><span class="p">&gt;</span>
@@ -1450,7 +1450,7 @@ if the API is under heavy load.</p>
 </span><span class="w">
 </span><span class="w"></span>services<span class="p">:</span><span class="w">
 </span><span class="w">
-</span><span class="w">  </span><span class="c"># your others services</span><span class="w">
+</span><span class="w">  </span><span class="c"># your other services</span><span class="w">
 </span><span class="w">
 </span><span class="w">  </span>gotenberg<span class="p">:</span><span class="w">
 </span><span class="w">    </span>image<span class="p">:</span><span class="w"> </span>thecodingmachine/gotenberg<span class="p">:</span><span class="m">6</span><span class="w">


### PR DESCRIPTION
Replaced others with singular form "other"
