### PR TITLE
use --font-render-hinting=none to fix kerning

### DIFF
--- a/internal/pkg/chrome/chrome.go
+++ b/internal/pkg/chrome/chrome.go
@@ -50,8 +50,9 @@ func cmd(logger xlog.Logger) (*exec.Cmd, error) {
 		"--headless",
 		// see https://github.com/thecodingmachine/gotenberg/issues/157.
 		"--disable-dev-shm-usage",
-		// see https://github.com/GoogleChrome/puppeteer/issues/2410.
-		"--font-render-hinting=medium",
+		// See https://github.com/puppeteer/puppeteer/issues/661
+		// and https://github.com/puppeteer/puppeteer/issues/2410.
+		"--font-render-hinting=none",
 		"--remote-debugging-port=9222",
 		"--disable-gpu",
 		"--disable-translate",


### PR DESCRIPTION
**Summary**

When using font render hinting on Chrome headless on Linux, the kerning is inconsistent. Several issues cover this, including:

* https://github.com/puppeteer/puppeteer/issues/661
* https://github.com/nzzdev/Q-server/pull/193

Disabling that render hinting entirely results in correct kerning. Related to this is #99, but unfortunately that fix still results in kerning issues.

Here is a PDF using various widths of the Roboto font:

| Before (v6.1.1) | After |
| - | - |
| <img width="917" alt="Screen Shot 2019-12-30 at 8 51 26 PM" src="https://user-images.githubusercontent.com/114033/71610489-632fbf00-2b46-11ea-9560-73c2c638b869.png"> | <img width="913" alt="Screen Shot 2019-12-30 at 8 51 34 PM" src="https://user-images.githubusercontent.com/114033/71610490-632fbf00-2b46-11ea-9fb3-af6e4ecd7d85.png"> |

Especially note the odd gaps in the bold text.

**Test plan (required)**

I rendered a PDF before and after this change, noting the odd kerning issues before and the fact that they were gone afterwards. Tested font is Roboto, both regular and bold.

**Closing issues**

None open.

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] Have you updated the documentation (Markdown files under `build > docs > content` and then `make doc`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
