### PR TITLE
Add support for Chrome scaling.

### DIFF
--- a/build/docs/content/04-html.md
+++ b/build/docs/content/04-html.md
@@ -243,11 +243,11 @@ $dest = 'result.pdf';
 $client->store($request, $dest);
 ```
 
-## Paper size, margins, orientation
+## Paper size, margins, orientation, scaling
 
 You may also customize the resulting PDF format.
 
-By default, it will be rendered with `A4` size, `1 inch` margins and `portrait` orientation.
+By default, it will be rendered with `A4` size, `1 inch` margins and `portrait` orientation and 100% (`1.0`) page scale.
 
 > Paper size and margins have to be provided in `inches`. Same for margins.
 
@@ -265,6 +265,7 @@ $ curl --request POST \
     --form marginLeft=0 \
     --form marginRight=0 \
     --form landscape=true \
+    --form scale=0.75 \
     -o result.pdf
 ```
 
@@ -279,6 +280,7 @@ req := gotenberg.NewHTMLRequest(index)
 req.PaperSize(gotenberg.A4)
 req.Margins(gotenberg.NoMargins)
 req.Landscape(true)
+req.Scale(0.75)
 dest := "result.pdf"
 c.Store(req, dest)
 ```
@@ -297,6 +299,7 @@ $request = new HTMLRequest($index);
 $request->setPaperSize(Request::A4);
 $request->setMargins(Request::NO_MARGINS);
 $request->setLandscape(true);
+$request->setScale(0.75);
 $dest = 'result.pdf';
 $client->store($request, $dest);
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -675,19 +675,19 @@ $dest = &#39;result.pdf&#39;;
 $client-&gt;store($request, $dest);
 </pre>
 
-<h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation" href="#html.paper_size_margins_orientation">
+<h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation_scaling" href="#html.paper_size_margins_orientation_scaling">
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
-</a>Paper size, margins, orientation</h2>
+</a>Paper size, margins, orientation, scaling</h2>
 
 <p>You may also customize the resulting PDF format.</p>
 
-<p>By default, it will be rendered with <code>A4</code> size, <code>1 inch</code> margins and <code>portrait</code> orientation.</p>
+<p>By default, it will be rendered with <code>A4</code> size, <code>1 inch</code> margins and <code>portrait</code> orientation and 100% (<code>1.0</code>) page scale.</p>
 
 <blockquote>
 <p>Paper size and margins have to be provided in <code>inches</code>. Same for margins.</p>
 </blockquote>
 
-<h3 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation.c_url" href="#html.paper_size_margins_orientation.c_url">
+<h3 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation_scaling.c_url" href="#html.paper_size_margins_orientation_scaling.c_url">
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>cURL</h3>
 
@@ -702,10 +702,11 @@ $client-&gt;store($request, $dest);
 </span><span class="se"></span>    --form <span class="nv">marginLeft</span><span class="o">=</span><span class="m">0</span> <span class="se">\
 </span><span class="se"></span>    --form <span class="nv">marginRight</span><span class="o">=</span><span class="m">0</span> <span class="se">\
 </span><span class="se"></span>    --form <span class="nv">landscape</span><span class="o">=</span><span class="nb">true</span> <span class="se">\
+</span><span class="se"></span>    --form <span class="nv">scale</span><span class="o">=</span>0.75 <span class="se">\
 </span><span class="se"></span>    -o result.pdf
 </pre>
 
-<h3 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation.go" href="#html.paper_size_margins_orientation.go">
+<h3 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation_scaling.go" href="#html.paper_size_margins_orientation_scaling.go">
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>Go</h3>
 
@@ -717,11 +718,12 @@ $client-&gt;store($request, $dest);
 <span class="nx">req</span><span class="p">.</span><span class="nf">PaperSize</span><span class="p">(</span><span class="nx">gotenberg</span><span class="p">.</span><span class="nx">A4</span><span class="p">)</span>
 <span class="nx">req</span><span class="p">.</span><span class="nf">Margins</span><span class="p">(</span><span class="nx">gotenberg</span><span class="p">.</span><span class="nx">NoMargins</span><span class="p">)</span>
 <span class="nx">req</span><span class="p">.</span><span class="nf">Landscape</span><span class="p">(</span><span class="kc">true</span><span class="p">)</span>
+<span class="nx">req</span><span class="p">.</span><span class="nf">Scale</span><span class="p">(</span><span class="mf">0.75</span><span class="p">)</span>
 <span class="nx">dest</span> <span class="o">:=</span> <span class="s">&#34;result.pdf&#34;</span>
 <span class="nx">c</span><span class="p">.</span><span class="nf">Store</span><span class="p">(</span><span class="nx">req</span><span class="p">,</span> <span class="nx">dest</span><span class="p">)</span>
 </pre>
 
-<h3 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation.php" href="#html.paper_size_margins_orientation.php">
+<h3 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation_scaling.php" href="#html.paper_size_margins_orientation_scaling.php">
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
@@ -736,6 +738,7 @@ $request = new HTMLRequest($index);
 $request-&gt;setPaperSize(Request::A4);
 $request-&gt;setMargins(Request::NO_MARGINS);
 $request-&gt;setLandscape(true);
+$request-&gt;setScale(0.75);
 $dest = &#39;result.pdf&#39;;
 $client-&gt;store($request, $dest);
 </pre>

--- a/internal/app/xhttp/option.go
+++ b/internal/app/xhttp/option.go
@@ -56,6 +56,10 @@ func chromePrinterOptions(r resource.Resource, config conf.Config) (printer.Chro
 		if err != nil {
 			return printer.ChromePrinterOptions{}, err
 		}
+		scale, err := resource.ScaleArg(r, config)
+		if err != nil {
+			return printer.ChromePrinterOptions{}, err
+		}
 		return printer.ChromePrinterOptions{
 			WaitTimeout:       waitTimeout,
 			WaitDelay:         waitDelay,
@@ -71,6 +75,7 @@ func chromePrinterOptions(r resource.Resource, config conf.Config) (printer.Chro
 			PageRanges:        pageRanges,
 			RpccBufferSize:    googleChromeRpccBufferSize,
 			CustomHTTPHeaders: make(map[string]string),
+			Scale:             scale,
 		}, nil
 	}
 	opts, err := resolver()

--- a/internal/app/xhttp/pkg/resource/arg.go
+++ b/internal/app/xhttp/pkg/resource/arg.go
@@ -57,6 +57,9 @@ const (
 	// GoogleChromeRpccBufferSizeArgKey is the key
 	// of the argument "googleChromeRpccBufferSize".
 	GoogleChromeRpccBufferSizeArgKey ArgKey = "googleChromeRpccBufferSize"
+	// ScaleArgKey is the key
+	// of the argument "scale".
+	ScaleArgKey ArgKey = "scale"
 )
 
 /*
@@ -81,6 +84,7 @@ func ArgKeys() []ArgKey {
 		LandscapeArgKey,
 		PageRangesArgKey,
 		GoogleChromeRpccBufferSizeArgKey,
+		ScaleArgKey,
 	}
 }
 
@@ -288,6 +292,30 @@ func GoogleChromeRpccBufferSizeArg(r Resource, config conf.Config) (int64, error
 		config.DefaultGoogleChromeRpccBufferSize(),
 		xassert.Int64NotInferiorTo(0.0),
 		xassert.Int64NotSuperiorTo(config.MaximumGoogleChromeRpccBufferSize()),
+	)
+	if err != nil {
+		return result, xerror.New(op, err)
+	}
+	return result, nil
+}
+
+/*
+ScaleArg is a helper for retrieving
+the "scale" argument as float64.
+
+It also validates it against the application
+configuration.
+*/
+func ScaleArg(r Resource, config conf.Config) (float64, error) {
+	const (
+		op           string  = "resource.ScaleArg"
+		defaultScale float64 = 1.0
+	)
+	result, err := r.Float64Arg(
+		ScaleArgKey,
+		defaultScale,
+		xassert.Float64NotInferiorTo(0.1),
+		xassert.Float64NotSuperiorTo(2.0),
 	)
 	if err != nil {
 		return result, xerror.New(op, err)

--- a/internal/app/xhttp/pkg/resource/arg_test.go
+++ b/internal/app/xhttp/pkg/resource/arg_test.go
@@ -26,6 +26,7 @@ func TestArgKeys(t *testing.T) {
 		LandscapeArgKey,
 		PageRangesArgKey,
 		GoogleChromeRpccBufferSizeArgKey,
+		ScaleArgKey,
 	}
 	assert.Equal(t, expected, ArgKeys())
 }
@@ -340,6 +341,53 @@ func TestGoogleChromeRpccBufferSizeArg(t *testing.T) {
 	expected = config.DefaultGoogleChromeRpccBufferSize()
 	r.WithArg(GoogleChromeRpccBufferSizeArgKey, "foo")
 	v, err = GoogleChromeRpccBufferSizeArg(r, config)
+	test.AssertError(t, err)
+	assert.Equal(t, expected, v)
+	// finally...
+	err = r.Close()
+	assert.Nil(t, err)
+}
+
+func TestScaleArg(t *testing.T) {
+	const (
+		resourceDirectoryName string  = "foo"
+		defaultValue          float64 = 1.0
+	)
+	var expected float64
+	logger := test.DebugLogger()
+	config := conf.DefaultConfig()
+	r, err := New(logger, resourceDirectoryName)
+	assert.Nil(t, err)
+	// argument does not exist.
+	expected = defaultValue
+	v, err := ScaleArg(r, config)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, v)
+	// argument exist.
+	expected = 0.5
+	r.WithArg(ScaleArgKey, "0.5")
+	v, err = ScaleArg(r, config)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, v)
+	// should not be OK as argument
+	// value is < 0.1.
+	expected = defaultValue
+	r.WithArg(ScaleArgKey, "-1.0")
+	v, err = ScaleArg(r, config)
+	test.AssertError(t, err)
+	assert.Equal(t, expected, v)
+	// should not be OK as argument
+	// value is > 2.0.
+	expected = defaultValue
+	r.WithArg(ScaleArgKey, "2.1")
+	v, err = ScaleArg(r, config)
+	test.AssertError(t, err)
+	assert.Equal(t, expected, v)
+	// should not be OK as
+	// argument value is invalid.
+	expected = defaultValue
+	r.WithArg(ScaleArgKey, "foo")
+	v, err = ScaleArg(r, config)
 	test.AssertError(t, err)
 	assert.Equal(t, expected, v)
 	// finally...

--- a/internal/pkg/printer/chrome.go
+++ b/internal/pkg/printer/chrome.go
@@ -45,6 +45,7 @@ type ChromePrinterOptions struct {
 	PageRanges        string
 	RpccBufferSize    int64
 	CustomHTTPHeaders map[string]string
+	Scale             float64
 }
 
 // DefaultChromePrinterOptions returns the default
@@ -66,6 +67,7 @@ func DefaultChromePrinterOptions(config conf.Config) ChromePrinterOptions {
 		PageRanges:        "",
 		RpccBufferSize:    config.DefaultGoogleChromeRpccBufferSize(),
 		CustomHTTPHeaders: make(map[string]string),
+		Scale:             1.0,
 	}
 }
 
@@ -176,7 +178,8 @@ func (p chromePrinter) Print(destination string) error {
 			SetDisplayHeaderFooter(true).
 			SetHeaderTemplate(p.opts.HeaderHTML).
 			SetFooterTemplate(p.opts.FooterHTML).
-			SetPrintBackground(true)
+			SetPrintBackground(true).
+			SetScale(p.opts.Scale)
 		if p.opts.PageRanges != "" {
 			printToPdfArgs.SetPageRanges(p.opts.PageRanges)
 		}


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **feature**:

* [X] Support for the "Scale" PDF print option

This came up as part of an unrelated use-case in which the resulting PDF needed to be printed at 85% scale.  I noticed that Gotenberg did not yet support the [PrintToPDFArgs.Scale](https://github.com/mafredri/cdp/blob/master/protocol/page/command.go#L323).  This change implements it as option `scale`.

**Test plan (required)**

Output for `make lint tests` is attached: [lint-tests-output.txt](https://github.com/thecodingmachine/gotenberg/files/4143149/lint-tests-output.txt).  One unrelated failure (also in the master branch) occurred.

End-to-end results manually verified in the resulting PDF, but by running the built Docker image with a port-forward:

```curl -XPOST http://localhost:3000/convert/html -H'Content-Type: multipart/form-data' --form files=@index.html --form scale=0.85 --form marginTop=0 --form marginBottom=0 --form marginLeft=0 --form marginRight=0 -o printed.pdf```

**Checklist**

- [X] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [X] Have you lint your code locally prior to submission (`make lint`)?
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally (`make tests`)?
- [X] Have you updated the documentation (Markdown files under `build > docs > content` and then `make doc`)?
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
