### PR TITLE
PDF/A support and HTML to PDF support for the Office endpoint 

### DIFF
--- a/build/docs/content/07-office.md
+++ b/build/docs/content/07-office.md
@@ -22,6 +22,7 @@ You may send one or more Office documents. Following file extensions are accepte
 * `.ppt`
 * `.pptx`
 * `.odp`
+* `.html`
 
 All files will be merged into a single resulting PDF.
 
@@ -164,4 +165,24 @@ $request = new OfficeRequest($files);
 $request->setPageRanges('1-3');
 $dest = 'result.pdf';
 $client->store($request, $dest);
+```
+
+## PDF/A-1 (ISO 19005-1:2005) compliant
+
+You can specify the rendered output to be PDF/A-1 (ISO 19005-1:2005) compliant.
+
+By default, the rendered output will not be not PDF/A-1 compliant
+
+The format is the same as the one from the export filter SelectPdfVersion of 
+LibreOffice, `0` PDF 1.x compliant or `1` PDF/A-1 compliant
+
+### cURL
+
+```bash
+$ curl --request POST \
+    --url http://localhost:3000/convert/office \
+    --header 'Content-Type: multipart/form-data' \
+    --form files=@document.docx \
+    --form selectPdfVersion='1' \
+    -o result.pdf
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,7 @@
 <p>For instance:</p>
 
 <pre class="chroma">$ git clone https://github.com/thecodingmachine/gotenberg.git
-$ make publish <span class="nv">GOTENBERG_USER_GID</span><span class="o">=</span>your_custom_gid <span class="nv">GOTENBERG_USER_UID</span><span class="o">=</span>your_custom_uid <span class="nv">DOCKER_REGISTRY</span><span class="o">=</span>your_registry <span class="nv">DOCKER_USER</span><span class="o">=</span>registry_user <span class="nv">DOCKER_PASSWORD</span><span class="o">=</span>registry_password <span class="nv">VERSION</span><span class="o">=</span>6.1.0 
+$ make publish <span class="nv">GOTENBERG_USER_GID</span><span class="o">=</span>your_custom_gid <span class="nv">GOTENBERG_USER_UID</span><span class="o">=</span>your_custom_uid <span class="nv">DOCKER_REGISTRY</span><span class="o">=</span>your_registry <span class="nv">DOCKER_USER</span><span class="o">=</span>registry_user <span class="nv">DOCKER_PASSWORD</span><span class="o">=</span>registry_password <span class="nv">VERSION</span><span class="o">=</span>6.2.0
 </pre>
 
 <blockquote>
@@ -1134,6 +1134,7 @@ $client-&gt;store($request, $dest);
 <li><code>.ppt</code></li>
 <li><code>.pptx</code></li>
 <li><code>.odp</code></li>
+<li><code>.html</code></li>
 </ul>
 
 <p>All files will be merged into a single resulting PDF.</p>
@@ -1294,6 +1295,29 @@ $request = new OfficeRequest($files);
 $request-&gt;setPageRanges(&#39;1-3&#39;);
 $dest = &#39;result.pdf&#39;;
 $client-&gt;store($request, $dest);
+</pre>
+
+<h2 class="Heading"><a class="Anchor" aria-hidden="true" id="office.pdf_a_1_iso_19005_1_2005_compliant" href="#office.pdf_a_1_iso_19005_1_2005_compliant">
+	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+</a>PDF/A-1 (ISO 19005-1:2005) compliant</h2>
+
+<p>You can specify the rendered output to be PDF/A-1 (ISO 19005-1:2005) compliant.</p>
+
+<p>By default, the rendered output will not be not PDF/A-1 compliant</p>
+
+<p>The format is the same as the one from the export filter SelectPdfVersion of
+LibreOffice, <code>0</code> PDF 1.x compliant or <code>1</code> PDF/A-1 compliant</p>
+
+<h3 class="Heading"><a class="Anchor" aria-hidden="true" id="office.pdf_a_1_iso_19005_1_2005_compliant.c_url" href="#office.pdf_a_1_iso_19005_1_2005_compliant.c_url">
+	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+</a>cURL</h3>
+
+<pre class="chroma">$ curl --request POST <span class="se">\
+</span><span class="se"></span>    --url http://localhost:3000/convert/office <span class="se">\
+</span><span class="se"></span>    --header <span class="s1">&#39;Content-Type: multipart/form-data&#39;</span> <span class="se">\
+</span><span class="se"></span>    --form <span class="nv">files</span><span class="o">=</span>@document.docx <span class="se">\
+</span><span class="se"></span>    --form <span class="nv">selectPdfVersion</span><span class="o">=</span><span class="s1">&#39;1&#39;</span> <span class="se">\
+</span><span class="se"></span>    -o result.pdf
 </pre>
 
               </div>

--- a/internal/app/xhttp/handler.go
+++ b/internal/app/xhttp/handler.go
@@ -214,6 +214,7 @@ func officeHandler(c echo.Context) error {
 			".ppt",
 			".pptx",
 			".odp",
+			".html",
 		)
 		if err != nil {
 			return err

--- a/internal/app/xhttp/handler_test.go
+++ b/internal/app/xhttp/handler_test.go
@@ -579,6 +579,13 @@ func TestOfficeHandler(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, endpoint, body)
 	req.Header.Set(echo.HeaderContentType, contentType)
 	test.AssertStatusCode(t, http.StatusBadRequest, srv, req)
+	// should return 400 as "selectPdfVersion" form field
+	// value is not an int.
+	body, contentType = test.OfficeMultipartForm(t, map[string]string{string(resource.SelectPdfVersionArgKey): "not an integer"})
+	req = httptest.NewRequest(http.MethodPost, endpoint, body)
+	req.Header.Set(echo.HeaderContentType, contentType)
+	test.AssertStatusCode(t, http.StatusBadRequest, srv, req)
+
 }
 
 func TestWebhook(t *testing.T) {

--- a/internal/app/xhttp/option.go
+++ b/internal/app/xhttp/option.go
@@ -96,14 +96,19 @@ func officePrinterOptions(r resource.Resource, config conf.Config) (printer.Offi
 		if err != nil {
 			return printer.OfficePrinterOptions{}, err
 		}
+		selectPdfVersion, err := r.Int64Arg(resource.SelectPdfVersionArgKey, 0)
+		if err != nil {
+			return printer.OfficePrinterOptions{}, err
+		}
 		pageRanges, err := r.StringArg(resource.PageRangesArgKey, "")
 		if err != nil {
 			return printer.OfficePrinterOptions{}, err
 		}
 		return printer.OfficePrinterOptions{
-			WaitTimeout: waitTimeout,
-			Landscape:   landscape,
-			PageRanges:  pageRanges,
+			WaitTimeout:      waitTimeout,
+			Landscape:        landscape,
+			SelectPdfVersion: selectPdfVersion,
+			PageRanges:       pageRanges,
 		}, nil
 	}
 	opts, err := resolver()

--- a/internal/app/xhttp/pkg/resource/arg.go
+++ b/internal/app/xhttp/pkg/resource/arg.go
@@ -51,6 +51,9 @@ const (
 	// LandscapeArgKey is the key
 	// of the argument "landscape".
 	LandscapeArgKey ArgKey = "landscape"
+	// SelectPdfVersionArgKey is the key
+	// of the argument "selectPdfVersion".
+	SelectPdfVersionArgKey ArgKey = "selectPdfVersion"
 	// PageRangesArgKey is the key
 	// of the argument "pageRanges".
 	PageRangesArgKey ArgKey = "pageRanges"
@@ -82,6 +85,7 @@ func ArgKeys() []ArgKey {
 		MarginLeftArgKey,
 		MarginRightArgKey,
 		LandscapeArgKey,
+		SelectPdfVersionArgKey,
 		PageRangesArgKey,
 		GoogleChromeRpccBufferSizeArgKey,
 		ScaleArgKey,
@@ -147,6 +151,27 @@ func WebhookURLTimeoutArg(r Resource, config conf.Config) (float64, error) {
 		config.DefaultWebhookURLTimeout(),
 		xassert.Float64NotInferiorTo(0),
 		xassert.Float64NotSuperiorTo(config.MaximumWebhookURLTimeout()),
+	)
+	if err != nil {
+		return result, xerror.New(op, err)
+	}
+	return result, nil
+}
+
+/*
+SelectPdfVersionArg is a helper for retrieving
+the "selectPdfVersionArg" argument as int64.
+
+It also validates it against the application
+configuration.
+*/
+func SelectPdfVersionArg(r Resource, config conf.Config) (int64, error) {
+	const op string = "resource.SelectPdfVersionArg"
+	result, err := r.Int64Arg(
+		SelectPdfVersionArgKey,
+		0,
+		xassert.Int64NotInferiorTo(0),
+		xassert.Int64NotSuperiorTo(1),
 	)
 	if err != nil {
 		return result, xerror.New(op, err)

--- a/internal/app/xhttp/pkg/resource/arg_test.go
+++ b/internal/app/xhttp/pkg/resource/arg_test.go
@@ -24,6 +24,7 @@ func TestArgKeys(t *testing.T) {
 		MarginLeftArgKey,
 		MarginRightArgKey,
 		LandscapeArgKey,
+		SelectPdfVersionArgKey,
 		PageRangesArgKey,
 		GoogleChromeRpccBufferSizeArgKey,
 		ScaleArgKey,
@@ -391,6 +392,40 @@ func TestScaleArg(t *testing.T) {
 	test.AssertError(t, err)
 	assert.Equal(t, expected, v)
 	// finally...
+	err = r.Close()
+	assert.Nil(t, err)
+}
+
+func TestSelectPdfVersiontArg(t *testing.T) {
+	const resourceDirectoryName string = "foo"
+	var expected int64
+	logger := test.DebugLogger()
+	config := conf.DefaultConfig()
+	r, err := New(logger, resourceDirectoryName)
+	assert.Nil(t, err)
+	// argument does not exist.
+	expected = 0
+	v, err := SelectPdfVersionArg(r, config)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, v)
+	//argument exist.
+	expected = 1
+	r.WithArg(SelectPdfVersionArgKey, "1")
+	v, err = SelectPdfVersionArg(r, config)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, v)
+	//argument < 0.
+	expected = 0
+	r.WithArg(SelectPdfVersionArgKey, "-1")
+	v, err = SelectPdfVersionArg(r, config)
+	test.AssertError(t, err)
+	assert.Equal(t, expected, v)
+	//argument > 1.
+	expected = 0
+	r.WithArg(SelectPdfVersionArgKey, "2")
+	v, err = SelectPdfVersionArg(r, config)
+	test.AssertError(t, err)
+	assert.Equal(t, expected, v)
 	err = r.Close()
 	assert.Nil(t, err)
 }

--- a/internal/pkg/printer/office.go
+++ b/internal/pkg/printer/office.go
@@ -26,18 +26,20 @@ type officePrinter struct {
 // OfficePrinterOptions helps customizing the
 // Office Printer behaviour.
 type OfficePrinterOptions struct {
-	WaitTimeout float64
-	Landscape   bool
-	PageRanges  string
+	WaitTimeout      float64
+	Landscape        bool
+	SelectPdfVersion int64
+	PageRanges       string
 }
 
 // DefaultOfficePrinterOptions returns the default
 // Office Printer options.
 func DefaultOfficePrinterOptions(config conf.Config) OfficePrinterOptions {
 	return OfficePrinterOptions{
-		WaitTimeout: config.DefaultWaitTimeout(),
-		Landscape:   false,
-		PageRanges:  "",
+		WaitTimeout:      config.DefaultWaitTimeout(),
+		SelectPdfVersion: 0,
+		Landscape:        false,
+		PageRanges:       "",
 	}
 }
 
@@ -108,6 +110,9 @@ func (p officePrinter) unoconv(ctx context.Context, fpath, destination string) e
 		}
 		if p.opts.Landscape {
 			args = append(args, "--printer", "PaperOrientation=landscape")
+		}
+		if p.opts.SelectPdfVersion >= 0 && p.opts.SelectPdfVersion <= 1 {
+			args = append(args, "--export", fmt.Sprintf("SelectPdfVersion=%d", p.opts.SelectPdfVersion))
 		}
 		if p.opts.PageRanges != "" {
 			args = append(args, "--export", fmt.Sprintf("PageRange=%s", p.opts.PageRanges))

--- a/internal/pkg/printer/office_test.go
+++ b/internal/pkg/printer/office_test.go
@@ -46,6 +46,15 @@ func TestOfficePrinter(t *testing.T) {
 	assert.Nil(t, err)
 	err = os.RemoveAll(dest)
 	assert.Nil(t, err)
+	// options with selectPdfVersion.
+	opts = DefaultOfficePrinterOptions(config)
+	opts.SelectPdfVersion = 1
+	p = NewOfficePrinter(logger, fpaths, opts)
+	dest = test.GenerateDestination()
+	err = p.Print(dest)
+	assert.Nil(t, err)
+	err = os.RemoveAll(dest)
+	assert.Nil(t, err)
 	// options with page ranges.
 	opts = DefaultOfficePrinterOptions(config)
 	opts.PageRanges = "1-1"


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [pull requests](../../../pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the [CONTRIBUTING](CONTRIBUTING.md) guide.

**Summary**

<!-- Summary of the PR -->

Add the possibility to generate PDF/A compliant output using the Office API
Add the possibility to generate PDF from HTML using the Office API, by whitelisting the .html extension.

This PR implements the following **features**
* [ X] Issue #120 

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

We needed a way to generate PDF/A from a HTML source. Unoconv was already able to do this, but needs an extra -export SelectPdfVersion=1 to the commandline. Because html file format isn't whitelisted for the /convert/office API and the headless chromium path isn't able to generate PDF/A we also whitelisted .html as a valid source

Because the headless chromium path isn't able to generate PDF/A  

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Leons-MacBook-Pro:gotenberg leon$ make lint
make workspace
make base
docker build --build-arg GOTENBERG_USER_GID=1001 --build-arg GOTENBERG_USER_UID=1001 -t thecodingmachine/gotenberg:base -f build/base/Dockerfile .
Sending build context to Docker daemon  33.12MB
Step 1/13 : FROM debian:buster-slim
 ---> 2f14a0fb67b9
Step 2/13 : RUN echo "deb http://httpredir.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list &&    apt-get update &&    apt-get install -y curl wget gnupg ttf-mscorefonts-installer procps
 ---> Using cache
 ---> e6f4bfe8df0d
Step 3/13 : RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - &&    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&    apt-get update &&    apt-get -y --allow-unauthenticated install google-chrome-stable
 ---> Using cache
 ---> 2d8e407de967
Step 4/13 : RUN mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&    echo "deb http://httpredir.debian.org/debian/ buster-backports main contrib non-free" >> /etc/apt/sources.list &&    apt-get update &&    apt-get -t buster-backports -y install libreoffice
 ---> Using cache
 ---> 9758c4d10264
Step 5/13 : ENV UNO_URL=https://raw.githubusercontent.com/dagwieers/unoconv/master/unoconv
 ---> Using cache
 ---> bbbb9ffabda3
Step 6/13 : RUN curl -Ls $UNO_URL -o /usr/bin/unoconv &&    chmod +x /usr/bin/unoconv &&    ln -s /usr/bin/python3 /usr/bin/python &&    unoconv --version
 ---> Using cache
 ---> a752dd8e0fc9
Step 7/13 : RUN apt-get -y install pdftk
 ---> Using cache
 ---> bb84270aa839
Step 8/13 : RUN apt-get install -y     culmus     fonts-beng     fonts-hosny-amiri     fonts-lklug-sinhala     fonts-lohit-guru     fonts-lohit-knda     fonts-samyak-gujr     fonts-samyak-mlym     fonts-samyak-taml     fonts-sarai     fonts-sil-abyssinica     fonts-sil-padauk     fonts-telu     fonts-thai-tlwg     fonts-liberation     ttf-wqy-zenhei     fonts-arphic-uming     fonts-ipafont-mincho     fonts-ipafont-gothic     fonts-unfonts-core
 ---> Using cache
 ---> 34cf0ded153b
Step 9/13 : COPY build/base/fonts/* /usr/local/share/fonts/
 ---> Using cache
 ---> 499d0436d248
Step 10/13 : COPY build/base/fonts.conf /etc/fonts/conf.d/100-gotenberg.conf
 ---> Using cache
 ---> ba53659b6864
Step 11/13 : ARG GOTENBERG_USER_GID=1001
 ---> Using cache
 ---> af26f93c4348
Step 12/13 : ARG GOTENBERG_USER_UID=1001
 ---> Using cache
 ---> 8a9f66d58d09
Step 13/13 : RUN groupadd --gid ${GOTENBERG_USER_GID} gotenberg   && useradd --uid ${GOTENBERG_USER_UID} --gid gotenberg --shell /bin/bash --home /gotenberg --no-create-home gotenberg   && mkdir /gotenberg   && chown gotenberg: /gotenberg
 ---> Using cache
 ---> 3367aef39b80
Successfully built 3367aef39b80
Successfully tagged thecodingmachine/gotenberg:base
docker build --build-arg GOLANG_VERSION=1.13 -t thecodingmachine/gotenberg:workspace -f build/workspace/Dockerfile . 
Sending build context to Docker daemon  33.12MB
Step 1/11 : ARG GOLANG_VERSION
Step 2/11 : FROM golang:${GOLANG_VERSION}-stretch as golang
 ---> 4fe257ac564c
Step 3/11 : FROM thecodingmachine/gotenberg:base
 ---> 3367aef39b80
Step 4/11 : RUN apt-get update && apt-get install -y --no-install-recommends         git 		g++ 		gcc 		libc6-dev 		make 		pkg-config 	&& rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 9129edc8e264
Step 5/11 : COPY --from=golang /usr/local/go /usr/local/go
 ---> Using cache
 ---> b84aae692ae5
Step 6/11 : ENV GOPATH /gotenberg/go
 ---> Using cache
 ---> 22d11e9d6705
Step 7/11 : ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 ---> Using cache
 ---> e15c7213a766
Step 8/11 : RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" &&    chmod -R 777 "$GOPATH"
 ---> Using cache
 ---> 6bf2668d47e9
Step 9/11 : USER gotenberg
 ---> Using cache
 ---> 28c0f28ad2fb
Step 10/11 : RUN go version &&    go env
 ---> Using cache
 ---> 90bcc11aad5f
Step 11/11 : USER root
 ---> Using cache
 ---> 7d979f5ae4e3
Successfully built 7d979f5ae4e3
Successfully tagged thecodingmachine/gotenberg:workspace
docker build --build-arg GOLANGCI_LINT_VERSION=1.20.1 -t thecodingmachine/gotenberg:lint -f build/lint/Dockerfile .
Sending build context to Docker daemon  33.12MB
Step 1/9 : FROM thecodingmachine/gotenberg:workspace
 ---> 7d979f5ae4e3
Step 2/9 : ARG GOLANGCI_LINT_VERSION
 ---> Using cache
 ---> c9759f433328
Step 3/9 : RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /usr/local/bin v${GOLANGCI_LINT_VERSION} &&    golangci-lint --version
 ---> Using cache
 ---> cdc2f5af87b4
Step 4/9 : USER gotenberg
 ---> Using cache
 ---> 7e3b996a34ab
Step 5/9 : WORKDIR /gotenberg/lint
 ---> Using cache
 ---> 0cec97f6ef23
Step 6/9 : COPY --chown=gotenberg:gotenberg go.mod go.sum ./
 ---> Using cache
 ---> 8f887e7bc5d8
Step 7/9 : RUN go mod download &&    go mod verify
 ---> Using cache
 ---> a7aa611752d1
Step 8/9 : COPY --chown=gotenberg:gotenberg . .
 ---> 1c3d9ee4c131
Step 9/9 : CMD ["golangci-lint", "run" ,"--tests=false", "--enable-all", "--disable=dupl", "--disable=funlen", "--disable=wsl", "--disable=gocognit" ]
 ---> Running in 4810c2f773ca
Removing intermediate container 4810c2f773ca
 ---> 79f2bc0d38e5
Successfully built 79f2bc0d38e5
Successfully tagged thecodingmachine/gotenberg:lint
docker run --rm thecodingmachine/gotenberg:lint
Leons-MacBook-Pro:gotenberg leon$ make tests
make workspace
make base
docker build --build-arg GOTENBERG_USER_GID=1001 --build-arg GOTENBERG_USER_UID=1001 -t thecodingmachine/gotenberg:base -f build/base/Dockerfile .
Sending build context to Docker daemon  33.12MB
Step 1/13 : FROM debian:buster-slim
 ---> 2f14a0fb67b9
Step 2/13 : RUN echo "deb http://httpredir.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list &&    apt-get update &&    apt-get install -y curl wget gnupg ttf-mscorefonts-installer procps
 ---> Using cache
 ---> e6f4bfe8df0d
Step 3/13 : RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - &&    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&    apt-get update &&    apt-get -y --allow-unauthenticated install google-chrome-stable
 ---> Using cache
 ---> 2d8e407de967
Step 4/13 : RUN mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&    echo "deb http://httpredir.debian.org/debian/ buster-backports main contrib non-free" >> /etc/apt/sources.list &&    apt-get update &&    apt-get -t buster-backports -y install libreoffice
 ---> Using cache
 ---> 9758c4d10264
Step 5/13 : ENV UNO_URL=https://raw.githubusercontent.com/dagwieers/unoconv/master/unoconv
 ---> Using cache
 ---> bbbb9ffabda3
Step 6/13 : RUN curl -Ls $UNO_URL -o /usr/bin/unoconv &&    chmod +x /usr/bin/unoconv &&    ln -s /usr/bin/python3 /usr/bin/python &&    unoconv --version
 ---> Using cache
 ---> a752dd8e0fc9
Step 7/13 : RUN apt-get -y install pdftk
 ---> Using cache
 ---> bb84270aa839
Step 8/13 : RUN apt-get install -y     culmus     fonts-beng     fonts-hosny-amiri     fonts-lklug-sinhala     fonts-lohit-guru     fonts-lohit-knda     fonts-samyak-gujr     fonts-samyak-mlym     fonts-samyak-taml     fonts-sarai     fonts-sil-abyssinica     fonts-sil-padauk     fonts-telu     fonts-thai-tlwg     fonts-liberation     ttf-wqy-zenhei     fonts-arphic-uming     fonts-ipafont-mincho     fonts-ipafont-gothic     fonts-unfonts-core
 ---> Using cache
 ---> 34cf0ded153b
Step 9/13 : COPY build/base/fonts/* /usr/local/share/fonts/
 ---> Using cache
 ---> 499d0436d248
Step 10/13 : COPY build/base/fonts.conf /etc/fonts/conf.d/100-gotenberg.conf
 ---> Using cache
 ---> ba53659b6864
Step 11/13 : ARG GOTENBERG_USER_GID=1001
 ---> Using cache
 ---> af26f93c4348
Step 12/13 : ARG GOTENBERG_USER_UID=1001
 ---> Using cache
 ---> 8a9f66d58d09
Step 13/13 : RUN groupadd --gid ${GOTENBERG_USER_GID} gotenberg   && useradd --uid ${GOTENBERG_USER_UID} --gid gotenberg --shell /bin/bash --home /gotenberg --no-create-home gotenberg   && mkdir /gotenberg   && chown gotenberg: /gotenberg
 ---> Using cache
 ---> 3367aef39b80
Successfully built 3367aef39b80
Successfully tagged thecodingmachine/gotenberg:base
docker build --build-arg GOLANG_VERSION=1.13 -t thecodingmachine/gotenberg:workspace -f build/workspace/Dockerfile . 
Sending build context to Docker daemon  33.12MB
Step 1/11 : ARG GOLANG_VERSION
Step 2/11 : FROM golang:${GOLANG_VERSION}-stretch as golang
 ---> 4fe257ac564c
Step 3/11 : FROM thecodingmachine/gotenberg:base
 ---> 3367aef39b80
Step 4/11 : RUN apt-get update && apt-get install -y --no-install-recommends         git 		g++ 		gcc 		libc6-dev 		make 		pkg-config 	&& rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 9129edc8e264
Step 5/11 : COPY --from=golang /usr/local/go /usr/local/go
 ---> Using cache
 ---> b84aae692ae5
Step 6/11 : ENV GOPATH /gotenberg/go
 ---> Using cache
 ---> 22d11e9d6705
Step 7/11 : ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 ---> Using cache
 ---> e15c7213a766
Step 8/11 : RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" &&    chmod -R 777 "$GOPATH"
 ---> Using cache
 ---> 6bf2668d47e9
Step 9/11 : USER gotenberg
 ---> Using cache
 ---> 28c0f28ad2fb
Step 10/11 : RUN go version &&    go env
 ---> Using cache
 ---> 90bcc11aad5f
Step 11/11 : USER root
 ---> Using cache
 ---> 7d979f5ae4e3
Successfully built 7d979f5ae4e3
Successfully tagged thecodingmachine/gotenberg:workspace
./scripts/tests.sh thecodingmachine 0
Sending build context to Docker daemon  33.12MB
Step 1/7 : FROM thecodingmachine/gotenberg:workspace
 ---> 7d979f5ae4e3
Step 2/7 : USER gotenberg
 ---> Using cache
 ---> 5a7a2c1d51af
Step 3/7 : WORKDIR /gotenberg/tests
 ---> Using cache
 ---> 964e8b765d3f
Step 4/7 : COPY --chown=gotenberg:gotenberg go.mod go.sum ./
 ---> Using cache
 ---> 8bd00ad46f41
Step 5/7 : RUN go mod download &&    go mod verify
 ---> Using cache
 ---> be91fa43ccbe
Step 6/7 : COPY --chown=gotenberg:gotenberg . .
 ---> Using cache
 ---> 1c9b36822d7f
Step 7/7 : ENTRYPOINT [ "build/tests/docker-entrypoint.sh" ]
 ---> Using cache
 ---> 2e0b893fe14b
Successfully built 2e0b893fe14b
Successfully tagged thecodingmachine/gotenberg:tests
++ whoami
+ CURRENT_USER=gotenberg
+ '[' gotenberg '!=' gotenberg ']'
+ go run test/cmd/chrome.go
+ '[' 0 = 1 ']'
+ go test -race -cover ./...
?   	github.com/thecodingmachine/gotenberg/cmd/gotenberg	[no test files]
ok  	github.com/thecodingmachine/gotenberg/internal/app/xhttp	41.472s	coverage: 89.5% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/app/xhttp/pkg/context	1.078s	coverage: 87.7% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/app/xhttp/pkg/resource	1.076s	coverage: 90.6% of statements
?   	github.com/thecodingmachine/gotenberg/internal/pkg/chrome	[no test files]
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/conf	1.084s	coverage: 100.0% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/normalize	1.033s	coverage: 83.3% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/printer	49.891s	coverage: 80.0% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/xassert	1.022s	coverage: 85.6% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/xcontext	2.018s	coverage: 100.0% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/xerror	1.019s	coverage: 100.0% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/xexec	1.043s	coverage: 85.9% of statements
?   	github.com/thecodingmachine/gotenberg/internal/pkg/xlog	[no test files]
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/xrand	1.074s	coverage: 100.0% of statements
ok  	github.com/thecodingmachine/gotenberg/internal/pkg/xtime	1.024s	coverage: 100.0% of statements
?   	github.com/thecodingmachine/gotenberg/test	[no test files]
?   	github.com/thecodingmachine/gotenberg/test/cmd	[no test files]




<!-- Make sure tests pass on Travis. -->

**Closing issues**

Fixes #120 

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [x ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] Have you updated the documentation (Markdown files under `build > docs > content` and then `make doc`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
