### PR TITLE
Url allow insecure connection

### DIFF
--- a/build/docs/content/03-environment-variables.md
+++ b/build/docs/content/03-environment-variables.md
@@ -58,9 +58,11 @@ The hard limit is 100 MB and is defined by Google Chrome itself.
 > The default Google Chrome rpcc buffer size may also be overridden per request thanks to the form field `googleChromeRpccBufferSize`.
 > See the [rpcc buffer size section](#html.rpcc_buffer_size).
 
-## Ignore certificate errors
+## Google Chrome ignore certificate errors
 
-By default Chrome will not accept certificate errors when using the URL print method. Setting this environment variable to `"1"` will allow insecure connections to be used. In dev environment for example. Be careful with this! Do not use in production.
+When performing a [URL](#url) conversion, Google Chrome will not accept certificate errors . 
+
+You may allow insecure connections by setting `GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS` variable to `"1"`. **You should be careful with this feature and only enable it in your development environment.**
 
 ## Disable LibreOffice (unoconv)
 

--- a/build/docs/content/03-environment-variables.md
+++ b/build/docs/content/03-environment-variables.md
@@ -58,6 +58,10 @@ The hard limit is 100 MB and is defined by Google Chrome itself.
 > The default Google Chrome rpcc buffer size may also be overridden per request thanks to the form field `googleChromeRpccBufferSize`.
 > See the [rpcc buffer size section](#html.rpcc_buffer_size).
 
+## Ignore certificate errors
+
+By default Chrome will not accept certificate errors when using the URL print method. Setting this environment variable to `"1"` will allow insecure connections to be used. In dev environment for example. Be careful with this! Do not use in production.
+
 ## Disable LibreOffice (unoconv)
 
 You may also disable LibreOffice (unoconv) with `DISABLE_UNOCONV`.

--- a/cmd/gotenberg/main.go
+++ b/cmd/gotenberg/main.go
@@ -28,7 +28,7 @@ func main() {
 	systemLogger.DebugOpf(op, "configuration: %+v", config)
 	if !config.DisableGoogleChrome() {
 		// start Google Chrome headless.
-		if err := chrome.Start(systemLogger, config.IgnoreCertificateErrors()); err != nil {
+		if err := chrome.Start(systemLogger, config.GoogleChromeIgnoreCertificateErrors()); err != nil {
 			systemLogger.FatalOp(op, err)
 		}
 	}

--- a/cmd/gotenberg/main.go
+++ b/cmd/gotenberg/main.go
@@ -28,7 +28,7 @@ func main() {
 	systemLogger.DebugOpf(op, "configuration: %+v", config)
 	if !config.DisableGoogleChrome() {
 		// start Google Chrome headless.
-		if err := chrome.Start(systemLogger); err != nil {
+		if err := chrome.Start(systemLogger, config.IgnoreCertificateErrors()); err != nil {
 			systemLogger.FatalOp(op, err)
 		}
 	}

--- a/docs/index.html
+++ b/docs/index.html
@@ -167,14 +167,14 @@ $ make publish <span class="nv">GOTENBERG_USER_GID</span><span class="o">=</span
 
 <p>You may also add it in your Docker Compose stack:</p>
 
-<pre class="chroma"><span class="k">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
+<pre class="chroma"><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
 </span><span class="w">
-</span><span class="w"></span><span class="k">services</span><span class="p">:</span><span class="w">
+</span><span class="w"></span><span class="nt">services</span><span class="p">:</span><span class="w">
 </span><span class="w">
 </span><span class="w">  </span><span class="c"># your other services</span><span class="w">
 </span><span class="w">
-</span><span class="w">  </span><span class="k">gotenberg</span><span class="p">:</span><span class="w">
-</span><span class="w">    </span><span class="k">image</span><span class="p">:</span><span class="w"> </span>thecodingmachine/gotenberg<span class="p">:</span><span class="m">6</span><span class="w">
+</span><span class="w">  </span><span class="nt">gotenberg</span><span class="p">:</span><span class="w">
+</span><span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">thecodingmachine/gotenberg:6</span><span class="w">
 </span></pre>
 
 <blockquote>
@@ -331,6 +331,12 @@ The hard limit is 100 MB and is defined by Google Chrome itself.</p>
 <p>The default Google Chrome rpcc buffer size may also be overridden per request thanks to the form field <code>googleChromeRpccBufferSize</code>.
 See the <a href="#html.rpcc_buffer_size">rpcc buffer size section</a>.</p>
 </blockquote>
+
+<h2 class="Heading"><a class="Anchor" aria-hidden="true" id="environment_variables.ignore_certificate_errors" href="#environment_variables.ignore_certificate_errors">
+	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+</a>Ignore certificate errors</h2>
+
+<p>By default the chrome instance will not accept certificate errors when using the URL print method. Setting this environment variable to <code>&#34;1&#34;</code> will allow insecure connections to be used. In dev environment for example. Be careful with this! Do not use in production.</p>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="environment_variables.disable_libre_office_unoconv" href="#environment_variables.disable_libre_office_unoconv">
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
@@ -1700,14 +1706,14 @@ if the API is under heavy load.</p>
 
 <p>For instance, using the following Docker Compose file:</p>
 
-<pre class="chroma"><span class="k">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
+<pre class="chroma"><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
 </span><span class="w">
-</span><span class="w"></span><span class="k">services</span><span class="p">:</span><span class="w">
+</span><span class="w"></span><span class="nt">services</span><span class="p">:</span><span class="w">
 </span><span class="w">
 </span><span class="w">  </span><span class="c"># your other services</span><span class="w">
 </span><span class="w">
-</span><span class="w">  </span><span class="k">gotenberg</span><span class="p">:</span><span class="w">
-</span><span class="w">    </span><span class="k">image</span><span class="p">:</span><span class="w"> </span>thecodingmachine/gotenberg<span class="p">:</span><span class="m">6</span><span class="w">
+</span><span class="w">  </span><span class="nt">gotenberg</span><span class="p">:</span><span class="w">
+</span><span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">thecodingmachine/gotenberg:6</span><span class="w">
 </span></pre>
 
 <p>You may now launch your services using:</p>

--- a/internal/pkg/chrome/chrome.go
+++ b/internal/pkg/chrome/chrome.go
@@ -16,11 +16,11 @@ import (
 )
 
 // Start starts Google Chrome headless in background.
-func Start(logger xlog.Logger) error {
+func Start(logger xlog.Logger, urlIgnoreCertificateErrors bool) error {
 	const op string = "chrome.Start"
 	logger.DebugOp(op, "starting new Google Chrome headless process on port 9222...")
 	resolver := func() error {
-		cmd, err := cmd(logger)
+		cmd, err := cmd(logger, urlIgnoreCertificateErrors)
 		if err != nil {
 			return err
 		}
@@ -32,7 +32,7 @@ func Start(logger xlog.Logger) error {
 		// if the process failed to start correctly,
 		// we have to restart it.
 		if !isViable(logger) {
-			return restart(logger, cmd.Process)
+			return restart(logger, cmd.Process, urlIgnoreCertificateErrors)
 		}
 		return nil
 	}
@@ -42,7 +42,7 @@ func Start(logger xlog.Logger) error {
 	return nil
 }
 
-func cmd(logger xlog.Logger) (*exec.Cmd, error) {
+func cmd(logger xlog.Logger, urlIgnoreCertificateErrors bool) (*exec.Cmd, error) {
 	const op string = "chrome.cmd"
 	binary := "google-chrome-stable"
 	args := []string{
@@ -66,6 +66,11 @@ func cmd(logger xlog.Logger) (*exec.Cmd, error) {
 		"--mute-audio",
 		"--no-first-run",
 	}
+
+	if urlIgnoreCertificateErrors {
+		args = append(args, "--ignore-certificate-errors")
+	}
+
 	cmd, err := xexec.Command(logger, binary, args...)
 	if err != nil {
 		return nil, xerror.New(op, err)
@@ -93,7 +98,7 @@ func kill(logger xlog.Logger, proc *os.Process) error {
 	return nil
 }
 
-func restart(logger xlog.Logger, proc *os.Process) error {
+func restart(logger xlog.Logger, proc *os.Process, urlIgnoreCertificateErrors bool) error {
 	const op string = "chrome.restart"
 	logger.DebugOp(op, "restarting Google Chrome headless process using port 9222...")
 	resolver := func() error {
@@ -101,7 +106,7 @@ func restart(logger xlog.Logger, proc *os.Process) error {
 		if err := kill(logger, proc); err != nil {
 			return err
 		}
-		cmd, err := cmd(logger)
+		cmd, err := cmd(logger, urlIgnoreCertificateErrors)
 		if err != nil {
 			return err
 		}
@@ -113,7 +118,7 @@ func restart(logger xlog.Logger, proc *os.Process) error {
 		// if the process failed to restart correctly,
 		// we have to restart it again.
 		if !isViable(logger) {
-			return restart(logger, cmd.Process)
+			return restart(logger, cmd.Process, urlIgnoreCertificateErrors)
 		}
 		return nil
 	}

--- a/internal/pkg/chrome/chrome.go
+++ b/internal/pkg/chrome/chrome.go
@@ -16,11 +16,11 @@ import (
 )
 
 // Start starts Google Chrome headless in background.
-func Start(logger xlog.Logger, urlIgnoreCertificateErrors bool) error {
+func Start(logger xlog.Logger, ignoreCertificateErrors bool) error {
 	const op string = "chrome.Start"
 	logger.DebugOp(op, "starting new Google Chrome headless process on port 9222...")
 	resolver := func() error {
-		cmd, err := cmd(logger, urlIgnoreCertificateErrors)
+		cmd, err := cmd(logger, ignoreCertificateErrors)
 		if err != nil {
 			return err
 		}
@@ -32,7 +32,7 @@ func Start(logger xlog.Logger, urlIgnoreCertificateErrors bool) error {
 		// if the process failed to start correctly,
 		// we have to restart it.
 		if !isViable(logger) {
-			return restart(logger, cmd.Process, urlIgnoreCertificateErrors)
+			return restart(logger, cmd.Process, ignoreCertificateErrors)
 		}
 		return nil
 	}
@@ -42,7 +42,7 @@ func Start(logger xlog.Logger, urlIgnoreCertificateErrors bool) error {
 	return nil
 }
 
-func cmd(logger xlog.Logger, urlIgnoreCertificateErrors bool) (*exec.Cmd, error) {
+func cmd(logger xlog.Logger, ignoreCertificateErrors bool) (*exec.Cmd, error) {
 	const op string = "chrome.cmd"
 	binary := "google-chrome-stable"
 	args := []string{
@@ -67,7 +67,7 @@ func cmd(logger xlog.Logger, urlIgnoreCertificateErrors bool) (*exec.Cmd, error)
 		"--no-first-run",
 	}
 
-	if urlIgnoreCertificateErrors {
+	if ignoreCertificateErrors {
 		args = append(args, "--ignore-certificate-errors")
 	}
 
@@ -98,7 +98,7 @@ func kill(logger xlog.Logger, proc *os.Process) error {
 	return nil
 }
 
-func restart(logger xlog.Logger, proc *os.Process, urlIgnoreCertificateErrors bool) error {
+func restart(logger xlog.Logger, proc *os.Process, ignoreCertificateErrors bool) error {
 	const op string = "chrome.restart"
 	logger.DebugOp(op, "restarting Google Chrome headless process using port 9222...")
 	resolver := func() error {
@@ -106,7 +106,7 @@ func restart(logger xlog.Logger, proc *os.Process, urlIgnoreCertificateErrors bo
 		if err := kill(logger, proc); err != nil {
 			return err
 		}
-		cmd, err := cmd(logger, urlIgnoreCertificateErrors)
+		cmd, err := cmd(logger, ignoreCertificateErrors)
 		if err != nil {
 			return err
 		}
@@ -118,7 +118,7 @@ func restart(logger xlog.Logger, proc *os.Process, urlIgnoreCertificateErrors bo
 		// if the process failed to restart correctly,
 		// we have to restart it again.
 		if !isViable(logger) {
-			return restart(logger, cmd.Process, urlIgnoreCertificateErrors)
+			return restart(logger, cmd.Process, ignoreCertificateErrors)
 		}
 		return nil
 	}

--- a/internal/pkg/conf/conf.go
+++ b/internal/pkg/conf/conf.go
@@ -40,8 +40,9 @@ const (
 	// DefaultGoogleChromeRpccBufferSizeEnvVar contains the name
 	// of the environment variable "DEFAULT_GOOGLE_CHROME_RPCC_BUFFER_SIZE".
 	DefaultGoogleChromeRpccBufferSizeEnvVar string = "DEFAULT_GOOGLE_CHROME_RPCC_BUFFER_SIZE"
-	// Allow self signed certificates when using a remote url
-	URLIgnoreCertificateErrorsEnvVar string = "URL_IGNORE_CERTIFICATE_ERRORS"
+      // GoogleChromeIgnoreCertificateErrorsEnvVar contains the name
+      // of the environment variable "GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS".
+	GoogleChromeIgnoreCertificateErrorsEnvVar string = "GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS"
 )
 
 // Config contains the application
@@ -55,7 +56,7 @@ type Config struct {
 	defaultListenPort                 int64
 	disableGoogleChrome               bool
 	disableUnoconv                    bool
-	urlIgnoreCertificateErrors        bool
+	googleChromeIgnoreCertificateErrors        bool
 	logLevel                          xlog.Level
 	rootPath                          string
 	maximumGoogleChromeRpccBufferSize int64
@@ -78,7 +79,7 @@ func DefaultConfig() Config {
 		rootPath:                          "/",
 		maximumGoogleChromeRpccBufferSize: 104857600, // ~100 MB
 		defaultGoogleChromeRpccBufferSize: 1048576,   // 1 MB
-		urlIgnoreCertificateErrors:        false,
+		googleChromeIgnoreCertificateErrors:        false,
 	}
 }
 
@@ -192,11 +193,11 @@ func FromEnv() (Config, error) {
 		if err != nil {
 			return c, err
 		}
-		urlIgnoreCertificateErrors, err := xassert.BoolFromEnv(
-			URLIgnoreCertificateErrorsEnvVar,
-			c.urlIgnoreCertificateErrors,
+		googleChromeIgnoreCertificateErrors, err := xassert.BoolFromEnv(
+			GoogleChromeIgnoreCertificateErrorsEnvVar,
+			c.googleChromeIgnoreCertificateErrors,
 		)
-		c.urlIgnoreCertificateErrors = urlIgnoreCertificateErrors
+		c.googleChromeIgnoreCertificateErrors = googleChromeIgnoreCertificateErrors
 		if err != nil {
 			return c, err
 		}
@@ -287,9 +288,6 @@ func (c Config) DefaultGoogleChromeRpccBufferSize() int64 {
 	return c.defaultGoogleChromeRpccBufferSize
 }
 
-// IgnoreCertificateErrors returns true if
-// Google Chrome should ignore certificate errors
-// in case of self signed certificates for example.
-func (c Config) IgnoreCertificateErrors() bool {
+func (c Config) GoogleChromeIgnoreCertificateErrors() bool {
 	return c.urlIgnoreCertificateErrors
 }

--- a/internal/pkg/conf/conf.go
+++ b/internal/pkg/conf/conf.go
@@ -40,6 +40,8 @@ const (
 	// DefaultGoogleChromeRpccBufferSizeEnvVar contains the name
 	// of the environment variable "DEFAULT_GOOGLE_CHROME_RPCC_BUFFER_SIZE".
 	DefaultGoogleChromeRpccBufferSizeEnvVar string = "DEFAULT_GOOGLE_CHROME_RPCC_BUFFER_SIZE"
+	// Allow self signed certificates when using a remote url
+	URLIgnoreCertificateErrorsEnvVar string = "URL_IGNORE_CERTIFICATE_ERRORS"
 )
 
 // Config contains the application
@@ -53,6 +55,7 @@ type Config struct {
 	defaultListenPort                 int64
 	disableGoogleChrome               bool
 	disableUnoconv                    bool
+	urlIgnoreCertificateErrors        bool
 	logLevel                          xlog.Level
 	rootPath                          string
 	maximumGoogleChromeRpccBufferSize int64
@@ -75,6 +78,7 @@ func DefaultConfig() Config {
 		rootPath:                          "/",
 		maximumGoogleChromeRpccBufferSize: 104857600, // ~100 MB
 		defaultGoogleChromeRpccBufferSize: 1048576,   // 1 MB
+		urlIgnoreCertificateErrors:        false,
 	}
 }
 
@@ -188,6 +192,14 @@ func FromEnv() (Config, error) {
 		if err != nil {
 			return c, err
 		}
+		urlIgnoreCertificateErrors, err := xassert.BoolFromEnv(
+			URLIgnoreCertificateErrorsEnvVar,
+			c.urlIgnoreCertificateErrors,
+		)
+		c.urlIgnoreCertificateErrors = urlIgnoreCertificateErrors
+		if err != nil {
+			return c, err
+		}
 		return c, nil
 	}
 	result, err := resolver()
@@ -273,4 +285,11 @@ func (c Config) MaximumGoogleChromeRpccBufferSize() int64 {
 //  Google Chrome rpcc buffer size from the configuration.
 func (c Config) DefaultGoogleChromeRpccBufferSize() int64 {
 	return c.defaultGoogleChromeRpccBufferSize
+}
+
+// IgnoreCertificateErrors returns true if
+// Google Chrome should ignore certificate errors
+// in case of self signed certificates for example.
+func (c Config) IgnoreCertificateErrors() bool {
+	return c.urlIgnoreCertificateErrors
 }

--- a/internal/pkg/conf/conf_test.go
+++ b/internal/pkg/conf/conf_test.go
@@ -380,6 +380,43 @@ func TestDefaultGoogleChromeRpccBufferSizeFromEnv(t *testing.T) {
 	os.Unsetenv(DefaultGoogleChromeRpccBufferSizeEnvVar)
 }
 
+func TestIgnoreCertificateErrorsFromEnv(t *testing.T) {
+	var (
+		expected Config
+		result   Config
+		err      error
+	)
+	// URL_IGNORE_CERTIFICATE_ERRORS correctly set to true.
+	os.Setenv(URLIgnoreCertificateErrorsEnvVar, "1")
+	expected = DefaultConfig()
+	expected.urlIgnoreCertificateErrors = true
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(URLIgnoreCertificateErrorsEnvVar)
+	// URL_IGNORE_CERTIFICATE_ERRORS correctly set to false.
+	os.Setenv(URLIgnoreCertificateErrorsEnvVar, "0")
+	expected = DefaultConfig()
+	expected.urlIgnoreCertificateErrors = false
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(URLIgnoreCertificateErrorsEnvVar)
+	// URL_IGNORE_CERTIFICATE_ERRORS wrongly set.
+	os.Setenv(URLIgnoreCertificateErrorsEnvVar, "foo")
+	expected = DefaultConfig()
+	result, err = FromEnv()
+	test.AssertError(t, err)
+	assert.Equal(t, expected, result)
+	os.Unsetenv(URLIgnoreCertificateErrorsEnvVar)
+	// URL_IGNORE_CERTIFICATE_ERRORS not set at all.
+	expected = DefaultConfig()
+	expected.urlIgnoreCertificateErrors = false
+	result, err = FromEnv()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
 func TestGetters(t *testing.T) {
 	result := DefaultConfig()
 	assert.Equal(t, result.maximumWaitTimeout, result.MaximumWaitTimeout())
@@ -394,4 +431,5 @@ func TestGetters(t *testing.T) {
 	assert.Equal(t, result.rootPath, result.RootPath())
 	assert.Equal(t, result.maximumGoogleChromeRpccBufferSize, result.MaximumGoogleChromeRpccBufferSize())
 	assert.Equal(t, result.defaultGoogleChromeRpccBufferSize, result.DefaultGoogleChromeRpccBufferSize())
+	assert.Equal(t, result.urlIgnoreCertificateErrors, result.IgnoreCertificateErrors())
 }

--- a/internal/pkg/conf/conf_test.go
+++ b/internal/pkg/conf/conf_test.go
@@ -380,38 +380,38 @@ func TestDefaultGoogleChromeRpccBufferSizeFromEnv(t *testing.T) {
 	os.Unsetenv(DefaultGoogleChromeRpccBufferSizeEnvVar)
 }
 
-func TestIgnoreCertificateErrorsFromEnv(t *testing.T) {
+func TestGoogleChromeIgnoreCertificateErrorsFromEnv(t *testing.T) {
 	var (
 		expected Config
 		result   Config
 		err      error
 	)
-	// URL_IGNORE_CERTIFICATE_ERRORS correctly set to true.
-	os.Setenv(URLIgnoreCertificateErrorsEnvVar, "1")
+	// GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS correctly set to true.
+	os.Setenv(GoogleChromeIgnoreCertificateErrorsEnvVar, "1")
 	expected = DefaultConfig()
-	expected.urlIgnoreCertificateErrors = true
+	expected.googleChromeIgnoreCertificateErrors = true
 	result, err = FromEnv()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
-	os.Unsetenv(URLIgnoreCertificateErrorsEnvVar)
-	// URL_IGNORE_CERTIFICATE_ERRORS correctly set to false.
-	os.Setenv(URLIgnoreCertificateErrorsEnvVar, "0")
+	os.Unsetenv(GoogleChromeIgnoreCertificateErrorsEnvVar)
+	// GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS correctly set to false.
+	os.Setenv(GooleChromeIgnoreCertificateErrorsEnvVar, "0")
 	expected = DefaultConfig()
-	expected.urlIgnoreCertificateErrors = false
+	expected.googleChromeIgnoreCertificateErrors = false
 	result, err = FromEnv()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
-	os.Unsetenv(URLIgnoreCertificateErrorsEnvVar)
-	// URL_IGNORE_CERTIFICATE_ERRORS wrongly set.
-	os.Setenv(URLIgnoreCertificateErrorsEnvVar, "foo")
+	os.Unsetenv(GoogleChromeIgnoreCertificateErrorsEnvVar)
+	// GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS wrongly set.
+	os.Setenv(GoogleChromeIgnoreCertificateErrorsEnvVar, "foo")
 	expected = DefaultConfig()
 	result, err = FromEnv()
 	test.AssertError(t, err)
 	assert.Equal(t, expected, result)
-	os.Unsetenv(URLIgnoreCertificateErrorsEnvVar)
-	// URL_IGNORE_CERTIFICATE_ERRORS not set at all.
+	os.Unsetenv(GoogleChromeIgnoreCertificateErrorsEnvVar)
+	// GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS not set at all.
 	expected = DefaultConfig()
-	expected.urlIgnoreCertificateErrors = false
+	expected.googleChromeIgnoreCertificateErrors = false
 	result, err = FromEnv()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
@@ -431,5 +431,5 @@ func TestGetters(t *testing.T) {
 	assert.Equal(t, result.rootPath, result.RootPath())
 	assert.Equal(t, result.maximumGoogleChromeRpccBufferSize, result.MaximumGoogleChromeRpccBufferSize())
 	assert.Equal(t, result.defaultGoogleChromeRpccBufferSize, result.DefaultGoogleChromeRpccBufferSize())
-	assert.Equal(t, result.urlIgnoreCertificateErrors, result.IgnoreCertificateErrors())
+	assert.Equal(t, result.googleChromeIgnoreCertificateErrors, result.GoogleChromeIgnoreCertificateErrors())
 }

--- a/test/cmd/chrome.go
+++ b/test/cmd/chrome.go
@@ -14,7 +14,7 @@ func main() {
 		systemLogger.FatalOp(op, err)
 	}
 	// start Google Chrome headless.
-	if err := chrome.Start(systemLogger, config.IgnoreCertificateErrors()); err != nil {
+	if err := chrome.Start(systemLogger, config.GoogleChromeIgnoreCertificateErrors()); err != nil {
 		systemLogger.FatalOp(op, err)
 	}
 }

--- a/test/cmd/chrome.go
+++ b/test/cmd/chrome.go
@@ -14,7 +14,7 @@ func main() {
 		systemLogger.FatalOp(op, err)
 	}
 	// start Google Chrome headless.
-	if err := chrome.Start(systemLogger); err != nil {
+	if err := chrome.Start(systemLogger, config.IgnoreCertificateErrors()); err != nil {
 		systemLogger.FatalOp(op, err)
 	}
 }


### PR DESCRIPTION
**Summary**
<!-- Summary of the PR -->
When using the remote URL conversions feature Chrome will not print when the remote URL provided has certificate errors. Self signed certificates are widely used in dev environments. This PR adds an environment variable that will make the user able to let Chrome ignore those certificate errors. 

This PR fixes/implements the following **features**

* [x] Feature #189 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

In our dev environment we use this container to print from another locally hosted URL that is secured with a self signed certificate. This PR will help us setup the dev environment as close to production as possible.


**Test plan (required)**
The unit tests are extended with a test for this environment variable. For the integration test I have printed a remote url that has a self signed certificate. It results in a white page, indicating that the rendering has failed.

After setting the URL_IGNORE_CERTIFICATE_ERRORS to "1" the same print request returns the correct printed html.

<!-- Make sure tests pass on Travis. -->


**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] Have you updated the documentation (Markdown files under `build > docs > content` and then `make doc`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
