### PR TITLE
Add the first version of the OpenAPI documentation

### DIFF
--- a/build/docs/content/15-links.md
+++ b/build/docs/content/15-links.md
@@ -9,3 +9,4 @@ title: Links
 * Follow the progress on the [GitHub repository](https://github.com/thecodingmachine/gotenberg)
 * Follow [@gulnap](https://twitter.com/gulnap) on Twitter
 * Thanks to [@mafredri](https://github.com/mafredri) for his help and his wonderful [cdp](https://github.com/mafredri/cdp) library
+* OpenAPI documentation for the API can be found [on GitHub](https://github.com/thecodingmachine/gotenberg/blob/master/docs/openapi.yaml)

--- a/docs/index.html
+++ b/docs/index.html
@@ -167,14 +167,14 @@ $ make publish <span class="nv">GOTENBERG_USER_GID</span><span class="o">=</span
 
 <p>You may also add it in your Docker Compose stack:</p>
 
-<pre class="chroma"><span class="k">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
+<pre class="chroma"><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
 </span><span class="w">
-</span><span class="w"></span><span class="k">services</span><span class="p">:</span><span class="w">
+</span><span class="w"></span><span class="nt">services</span><span class="p">:</span><span class="w">
 </span><span class="w">
 </span><span class="w">  </span><span class="c"># your other services</span><span class="w">
 </span><span class="w">
-</span><span class="w">  </span><span class="k">gotenberg</span><span class="p">:</span><span class="w">
-</span><span class="w">    </span><span class="k">image</span><span class="p">:</span><span class="w"> </span>thecodingmachine/gotenberg<span class="p">:</span><span class="m">6</span><span class="w">
+</span><span class="w">  </span><span class="nt">gotenberg</span><span class="p">:</span><span class="w">
+</span><span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">thecodingmachine/gotenberg:6</span><span class="w">
 </span></pre>
 
 <blockquote>
@@ -481,15 +481,15 @@ which will be converted to PDF.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.header_and_footer" href="#html.header_and_footer">
@@ -573,19 +573,19 @@ Respectively, a file named <code>header.html</code> and <code>footer.html</code>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$header = DocumentFactory::makeFromPath(&#39;header.html&#39;, &#39;/path/to/file&#39;);
-$footer = DocumentFactory::makeFromPath(&#39;footer.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setHeader($header);
-$request-&gt;setFooter($footer);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$header</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;header.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$footer</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;footer.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setHeader</span><span class="p">(</span><span class="nv">$header</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setFooter</span><span class="p">(</span><span class="nv">$footer</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.assets" href="#html.assets">
@@ -669,21 +669,21 @@ see to the <a href="#fonts">fonts section</a>.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$assets = [
-    DocumentFactory::makeFromPath(&#39;style.css&#39;, &#39;/path/to/file&#39;),
-    DocumentFactory::makeFromPath(&#39;img.png&#39;, &#39;/path/to/file&#39;),
-    DocumentFactory::makeFromPath(&#39;font.woff&#39;, &#39;/path/to/file&#39;),
-];
-$request = new HTMLRequest($index);
-$request-&gt;setAssets($assets);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$assets</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;style.css&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;img.png&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;font.woff&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+<span class="p">];</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setAssets</span><span class="p">(</span><span class="nv">$assets</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.paper_size_margins_orientation_scaling" href="#html.paper_size_margins_orientation_scaling">
@@ -738,20 +738,20 @@ $client-&gt;store($request, $dest);
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
-use TheCodingMachine\Gotenberg\Request;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Request</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setPaperSize(Request::A4);
-$request-&gt;setMargins(Request::NO_MARGINS);
-$request-&gt;setLandscape(true);
-$request-&gt;setScale(0.75);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setPaperSize</span><span class="p">(</span><span class="nx">Request</span><span class="o">::</span><span class="na">A4</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setMargins</span><span class="p">(</span><span class="nx">Request</span><span class="o">::</span><span class="na">NO_MARGINS</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setLandscape</span><span class="p">(</span><span class="k">true</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setScale</span><span class="p">(</span><span class="mf">0.75</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.page_ranges" href="#html.page_ranges">
@@ -793,17 +793,17 @@ of Google Chrome, e.g. <code>1-5,8,11-13</code>.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
-use TheCodingMachine\Gotenberg\Request;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Request</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setPageRanges(&#39;1-3,5&#39;);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setPageRanges</span><span class="p">(</span><span class="s1">&#39;1-3,5&#39;</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.wait_delay" href="#html.wait_delay">
@@ -848,17 +848,17 @@ a lot on JavaScript for rendering.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
-use TheCodingMachine\Gotenberg\Request;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Request</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setWaitDelay(5.5);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setWaitDelay</span><span class="p">(</span><span class="mf">5.5</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="html.rpcc_buffer_size" href="#html.rpcc_buffer_size">
@@ -906,17 +906,17 @@ The hard limit is 100 MB and is defined by Google Chrome itself.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
-use TheCodingMachine\Gotenberg\Request;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Request</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setGoogleChromeRpccBufferSize(1048576);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setGoogleChromeRpccBufferSize</span><span class="p">(</span><span class="mi">1048576</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -976,14 +976,14 @@ the resulting PDF will be blank. Make sure to rename your service to avoid this 
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\URLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\URLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$request = new URLRequest(&#39;https://google.com&#39;);
-$request-&gt;setMargins(Request::NO_MARGINS);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">URLRequest</span><span class="p">(</span><span class="s1">&#39;https://google.com&#39;</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setMargins</span><span class="p">(</span><span class="nx">Request</span><span class="o">::</span><span class="na">NO_MARGINS</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="url.custom_http_headers" href="#url.custom_http_headers">
@@ -1032,14 +1032,14 @@ canonical key for <code>accept-encoding</code> is <code>Accept-Encoding</code>.<
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\URLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\URLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$request = new URLRequest(&#39;https://google.com&#39;);
-$request-&gt;addRemoteURLHTTPHeader(&#39;Your-Header&#39;, &#39;Foo&#39;)
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">URLRequest</span><span class="p">(</span><span class="s1">&#39;https://google.com&#39;</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">addRemoteURLHTTPHeader</span><span class="p">(</span><span class="s1">&#39;Your-Header&#39;</span><span class="p">,</span> <span class="s1">&#39;Foo&#39;</span><span class="p">)</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -1105,18 +1105,18 @@ in the file <code>index.html</code>. This function will convert a given markdown
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\MarkdownRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\MarkdownRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$markdowns = [
-    DocumentFactory::makeFromPath(&#39;file.md&#39;, &#39;/path/to/file&#39;),
-];
-$request = new MarkdownRequest($index, $markdowns);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$markdowns</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;file.md&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+<span class="p">];</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">MarkdownRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">,</span> <span class="nv">$markdowns</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -1186,18 +1186,18 @@ $client-&gt;store($request, $dest);
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\OfficeRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\OfficeRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$files = [
-    DocumentFactory::makeFromPath(&#39;document.docx&#39;, &#39;/path/to/file&#39;),
-    DocumentFactory::makeFromPath(&#39;document2.docx&#39;, &#39;/path/to/file&#39;),
-];
-$request = new OfficeRequest($files);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$files</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;document.docx&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;document2.docx&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+<span class="p">];</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">OfficeRequest</span><span class="p">(</span><span class="nv">$files</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="office.orientation" href="#office.orientation">
@@ -1238,18 +1238,18 @@ $client-&gt;store($request, $dest);
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\OfficeRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\OfficeRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$files = [
-    DocumentFactory::makeFromPath(&#39;document.docx&#39;, &#39;/path/to/file&#39;),
-];
-$request = new OfficeRequest($files);
-$request-&gt;setLandscape(true);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$files</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;document.docx&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+<span class="p">];</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">OfficeRequest</span><span class="p">(</span><span class="nv">$files</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setLandscape</span><span class="p">(</span><span class="k">true</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="office.page_ranges" href="#office.page_ranges">
@@ -1296,18 +1296,18 @@ applied for each document.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\OfficeRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\OfficeRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$files = [
-    DocumentFactory::makeFromPath(&#39;document.docx&#39;, &#39;/path/to/file&#39;),
-];
-$request = new OfficeRequest($files);
-$request-&gt;setPageRanges(&#39;1-3&#39;);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$files</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;document.docx&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+<span class="p">];</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">OfficeRequest</span><span class="p">(</span><span class="nv">$files</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setPageRanges</span><span class="p">(</span><span class="s1">&#39;1-3&#39;</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -1361,18 +1361,18 @@ will merge them and return the resulting PDF file.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\MergeRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\MergeRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$files = [
-    DocumentFactory::makeFromPath(&#39;file.pdf&#39;, &#39;/path/to/file&#39;),
-    DocumentFactory::makeFromPath(&#39;file2.pdf&#39;, &#39;/path/to/file&#39;),
-];
-$request = new MergeRequest($files);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$files</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;file.pdf&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+    <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;file2.pdf&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">),</span>
+<span class="p">];</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">MergeRequest</span><span class="p">(</span><span class="nv">$files</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -1424,17 +1424,17 @@ If unsucessful, it returns a <code>504</code> HTTP code.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
-use TheCodingMachine\Gotenberg\Request;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Request</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setWaitTimeout(2.5);
-$dest = &#39;result.pdf&#39;;
-$client-&gt;store($request, $dest);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setWaitTimeout</span><span class="p">(</span><span class="mf">2.5</span><span class="p">);</span>
+<span class="nv">$dest</span> <span class="o">=</span> <span class="s1">&#39;result.pdf&#39;</span><span class="p">;</span>
+<span class="nv">$client</span><span class="o">-&gt;</span><span class="na">store</span><span class="p">(</span><span class="nv">$request</span><span class="p">,</span> <span class="nv">$dest</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -1482,15 +1482,15 @@ to given URL.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setWebhookURL(&#39;http://myapp.com/webhook/&#39;);
-$resp = $client-&gt;post($request);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setWebhookURL</span><span class="p">(</span><span class="s1">&#39;http://myapp.com/webhook/&#39;</span><span class="p">);</span>
+<span class="nv">$resp</span> <span class="o">=</span> <span class="nv">$client</span><span class="o">-&gt;</span><span class="na">post</span><span class="p">(</span><span class="nv">$request</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="webhook.timeout" href="#webhook.timeout">
@@ -1537,16 +1537,16 @@ $resp = $client-&gt;post($request);
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setWebhookURL(&#39;http://myapp.com/webhook/&#39;);
-$request-&gt;setWebhookURLTimeout(2.5);
-$resp = $client-&gt;post($request);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setWebhookURL</span><span class="p">(</span><span class="s1">&#39;http://myapp.com/webhook/&#39;</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setWebhookURLTimeout</span><span class="p">(</span><span class="mf">2.5</span><span class="p">);</span>
+<span class="nv">$resp</span> <span class="o">=</span> <span class="nv">$client</span><span class="o">-&gt;</span><span class="na">post</span><span class="p">(</span><span class="nv">$request</span><span class="p">);</span>
 </pre>
 
 <h2 class="Heading"><a class="Anchor" aria-hidden="true" id="webhook.custom_http_headers" href="#webhook.custom_http_headers">
@@ -1596,16 +1596,16 @@ canonical key for <code>accept-encoding</code> is <code>Accept-Encoding</code>.<
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setWebhookURL(&#39;http://myapp.com/webhook/&#39;);
-$request-&gt;addWebhookURLHTTPHeader(&#39;Your-Header&#39;, &#39;Foo&#39;);
-$resp = $client-&gt;post($request);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setWebhookURL</span><span class="p">(</span><span class="s1">&#39;http://myapp.com/webhook/&#39;</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">addWebhookURLHTTPHeader</span><span class="p">(</span><span class="s1">&#39;Your-Header&#39;</span><span class="p">,</span> <span class="s1">&#39;Foo&#39;</span><span class="p">);</span>
+<span class="nv">$resp</span> <span class="o">=</span> <span class="nv">$client</span><span class="o">-&gt;</span><span class="na">post</span><span class="p">(</span><span class="nv">$request</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -1655,16 +1655,16 @@ Otherwise a random filename is used.</p>
 	<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 </a>PHP</h3>
 
-<pre class="chroma">use TheCodingMachine\Gotenberg\Client;
-use TheCodingMachine\Gotenberg\DocumentFactory;
-use TheCodingMachine\Gotenberg\HTMLRequest;
-use TheCodingMachine\Gotenberg\Request;
+<pre class="chroma"><span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Client</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\DocumentFactory</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\HTMLRequest</span><span class="p">;</span>
+<span class="k">use</span> <span class="nx">TheCodingMachine\Gotenberg\Request</span><span class="p">;</span>
 
-$client = new Client(&#39;http://localhost:3000&#39;, new \Http\Adapter\Guzzle6\Client());
-$index = DocumentFactory::makeFromPath(&#39;index.html&#39;, &#39;/path/to/file&#39;);
-$request = new HTMLRequest($index);
-$request-&gt;setResultFilename(&#39;foo.pdf&#39;);
-$resp = $client-&gt;post($request);
+<span class="nv">$client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Client</span><span class="p">(</span><span class="s1">&#39;http://localhost:3000&#39;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">\Http\Adapter\Guzzle6\Client</span><span class="p">());</span>
+<span class="nv">$index</span> <span class="o">=</span> <span class="nx">DocumentFactory</span><span class="o">::</span><span class="na">makeFromPath</span><span class="p">(</span><span class="s1">&#39;index.html&#39;</span><span class="p">,</span> <span class="s1">&#39;/path/to/file&#39;</span><span class="p">);</span>
+<span class="nv">$request</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">HTMLRequest</span><span class="p">(</span><span class="nv">$index</span><span class="p">);</span>
+<span class="nv">$request</span><span class="o">-&gt;</span><span class="na">setResultFilename</span><span class="p">(</span><span class="s1">&#39;foo.pdf&#39;</span><span class="p">);</span>
+<span class="nv">$resp</span> <span class="o">=</span> <span class="nv">$client</span><span class="o">-&gt;</span><span class="na">post</span><span class="p">(</span><span class="nv">$request</span><span class="p">);</span>
 </pre>
 
               </div>
@@ -1713,14 +1713,14 @@ if the API is under heavy load.</p>
 
 <p>For instance, using the following Docker Compose file:</p>
 
-<pre class="chroma"><span class="k">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
+<pre class="chroma"><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="s1">&#39;3&#39;</span><span class="w">
 </span><span class="w">
-</span><span class="w"></span><span class="k">services</span><span class="p">:</span><span class="w">
+</span><span class="w"></span><span class="nt">services</span><span class="p">:</span><span class="w">
 </span><span class="w">
 </span><span class="w">  </span><span class="c"># your other services</span><span class="w">
 </span><span class="w">
-</span><span class="w">  </span><span class="k">gotenberg</span><span class="p">:</span><span class="w">
-</span><span class="w">    </span><span class="k">image</span><span class="p">:</span><span class="w"> </span>thecodingmachine/gotenberg<span class="p">:</span><span class="m">6</span><span class="w">
+</span><span class="w">  </span><span class="nt">gotenberg</span><span class="p">:</span><span class="w">
+</span><span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">thecodingmachine/gotenberg:6</span><span class="w">
 </span></pre>
 
 <p>You may now launch your services using:</p>
@@ -1778,7 +1778,8 @@ restart your Gotenberg instances from time to time to ensure a nominal behaviour
 <ul>
 <li>Follow the progress on the <a href="https://github.com/thecodingmachine/gotenberg">GitHub repository</a></li>
 <li>Follow <a href="https://twitter.com/gulnap">@gulnap</a> on Twitter</li>
-<li>Thanks to <a href="https://github.com/mafredri">@mafredri</a> for its help and its wonderful <a href="https://github.com/mafredri/cdp">cdp</a> library</li>
+<li>Thanks to <a href="https://github.com/mafredri">@mafredri</a> for his help and his wonderful <a href="https://github.com/mafredri/cdp">cdp</a> library</li>
+<li>OpenAPI documentation for the API can be found <a href="https://github.com/thecodingmachine/gotenberg/blob/master/docs/openapi.yaml">on GitHub</a></li>
 </ul>
 
               </div>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,558 @@
+openapi: 3.0.0
+info:
+  title: Gotenberg
+  version: 6.3.1
+  license:
+    name: MIT
+    url: 'https://github.com/thecodingmachine/gotenberg/blob/master/LICENSE'
+  contact:
+    url: 'https://github.com/thecodingmachine/gotenberg'
+  description: >-
+    A Docker-powered stateless API for converting HTML, Markdown and Office
+    documents to PDF.
+servers:
+  - url: 'http://localhost:3000'
+    description: Local server with the default Docker image and port
+paths:
+  /convert/html:
+    post:
+      summary: Convert a given HTML file to PDF
+      description: >-
+        Send an HTML file called `index.html` as a multipart form request, and
+        get the resulting PDF file. You can optionally include `header.html` and
+        `footer.html` files as part of the request as well.
+
+
+        An example `index.html` file can be as follows:
+
+        ```html
+
+        <!doctype html>
+
+        <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>My PDF</title>
+          </head>
+          <body>
+            <h1>Hello world!</h1>
+          </body>
+        </html>
+
+        ```
+
+
+        You may also add a header and/or a footer in the resulting PDF  by
+        sending a file named `header.html` and `footer.html` respectively. Both
+        the header and the footer files has to be a complete HTML document. An
+        example `footer.html` can be as follows:
+
+        ```html
+
+        <html>
+            <head>
+                <style>
+                    body {
+                        font-size: 8rem;
+                        margin: 4rem auto;
+                    }
+                </style>
+            </head>
+            <body>
+                <p>
+                    <span class="pageNumber"></span> of <span class="totalPages"></span>
+                </p>
+            </body>
+        </html>
+
+        ```
+
+
+        The following classes will allow you to inject printing values in your
+        document:
+
+        - `date`: Formatted print date.
+
+        - `title`: Document title.
+
+        - `pageNumber`: Current page number.
+
+        - `totalPage`: Total pages in the document.
+
+
+        There are some limitations with header and footer files:
+
+        - JavaScript is not executed.
+
+        - External resources are not loaded.
+
+        - The CSS properties are independant of the ones used in the
+        `index.html` file.
+
+        - `footer.html` CSS properties override the ones from `header.html`.
+
+        - Only fonts installed in the Docker image are loaded (see the fonts
+        section)
+
+        - Images only work using a `base64` encoded source, e.g. `<img
+        src="data:image/png;base64, iVBORw0K... />`
+
+        - `background-color` and `color` CSS properties require an additional
+        `-webkit-print-color-adjust: exact` CSS property in order to work.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HTMLConvertRequestBody'
+        description: >-
+          The request body must have an `index.html` file in the `files` array,
+          as well as all the referred resources on the same level as the
+          `index.html` file. The request can also include `header.html` and
+          `footer.html`, given the limitations in the API description above.
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessfulPDF'
+  /convert/url:
+    post:
+      summary: Convert the contents of a given URL to PDF
+      description: >-
+        Send a remote URL in your API request via the `remoteURL` parameter, and
+        get the resulting PDF file. The API will fetch the given URL and render
+        the page to PDF using the underlying headless Chrome instance.
+      requestBody:
+        required: true
+        description: >-
+          The URL conversion request has to be a `multipart/form-data` request
+          that includes a `remoteURL`. The API uses a headless Chrome instance
+          to do the conversion, therefore print parameter such as margins and
+          paper size are also accepted as optional parameters.
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/URLConvertRequestBody'
+            examples: {}
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessfulPDF'
+  /convert/markdown:
+    post:
+      summary: Convert a Markdown file to PDF
+      description: >-
+        Send an HTML file called `index.html` as a multipart form request and
+        embed a markdown file into the HTML file using the Golang template
+        function `toHTML`, the API will convert the markdown and embed it into
+        the HTML this way and render the resulting page. Markdown conversion
+        works almost exactly the same way as HTML conversion, therefore refer to
+        the HTML conversion page for all the options you can use when converting
+        Markdown documents as well. You can optionally include `header.html` and
+        `footer.html` files as part of the request as well.
+
+
+        An example `index.html` file can be as follows:
+
+        ```html
+
+        <!doctype html>
+
+        <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>My PDF</title>
+          </head>
+          <body>
+            {{ toHTML .DirPath "file.md" }}
+          </body>
+        </html>
+
+        ```
+
+
+        Whereas your `file.md` file in the same level would be like:
+
+        ```md
+
+        # Title
+
+        Content
+
+        ```
+
+
+        The API will convert the markdown to HTML and embed it into your
+        `index.html` file, then render the resulting page. You can include your
+        own styling and more in your HTML file.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/MarkdownConvertRequestBody'
+        description: >-
+          The request body must have an `index.html` file in the `files` array,
+          as well as all the referred markdown resources on the same level as
+          the `index.html` file.
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessfulPDF'
+  /convert/office:
+    post:
+      summary: Convert an Office document to PDF
+      description: >-
+        Send one or more Office documents and get the resulting PDF file by
+        merging all the files. The following file extensions are accepted:
+
+        - `.txt`
+
+        - `.rtf`
+
+        - `.fodt`
+
+        - `.doc`
+
+        - `.docx`
+
+        - `.odt`
+
+        - `.xls`
+
+        - `.xlsx`
+
+        - `.ods`
+
+        - `.ppt`
+
+        - `.pptx`
+
+        - `.odp`
+
+
+        All files will be merged into a single PDF.
+
+        > **Attention:** The files will be merged alphabetically for the
+        resulting PDF.
+
+
+        You may also specify the page ranges to convert from the incoming Office
+        documents. The expected format is the same as the one from the print
+        options of LibreOffice, e.g. `1-1` or `1-4`.
+
+
+        > **Attention:** if more than one document, the page ranges will be
+        applied for each document.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/OfficeConvertRequestBody'
+        description: >-
+          The request body must have an `index.html` file in the `files` array,
+          as well as all the referred markdown resources on the same level as
+          the `index.html` file.
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessfulPDF'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+  /convert/merge:
+    post:
+      summary: Merge multiple PDFs into a single PDF
+      description: >-
+        You can send multiple PDF files to this endpoint, the API will merge
+        them into a single PDF and return the resulting PDF file.
+
+
+        > **Attention:** The PDF files will be merged alphabetically.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  description: >-
+                    List of HTML files to be converted to PDF. An `index.html`
+                    file is required, and any other resources that are
+                    referenced through the HTML file must be included as well.
+                    All the referenced files must be on the same level as the
+                    `index.html` file.
+                  items:
+                    type: string
+                    format: binary
+                resultFilename:
+                  type: string
+                  example: output.pdf
+                  description: >-
+                    If provided, the API will return the resulting PDF file with
+                    the given filename. Otherwise a random filename is used.
+              required:
+                - files
+        description: >-
+          The request body must have an `index.html` file in the `files` array,
+          as well as all the referred markdown resources on the same level as
+          the `index.html` file.
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessfulPDF'
+  /ping:
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses:
+        '200':
+          description: The API is working fine.
+      operationId: ''
+      description: >-
+        A simple endpoint to use as a healthcheck for the API availability with
+        a simple request.
+components:
+  schemas:
+    HTMLConvertRequestBody:
+      title: HTML Conversion Request Body
+      type: object
+      properties:
+        files:
+          type: array
+          description: >-
+            List of HTML files to be converted to PDF. An `index.html` file is
+            required, and any other resources that are referenced through the
+            HTML file must be included as well. All the referenced files must be
+            on the same level as the `index.html` file.
+          items:
+            type: string
+            format: binary
+        marginTop:
+          type: number
+          example: 0
+          default: 1
+          description: Top margin for the page in inches.
+        marginBottom:
+          type: number
+          example: 0
+          default: 1
+          description: Bottom margin for the page in inches.
+        marginLeft:
+          type: number
+          example: 0
+          default: 1
+          description: Left margin for the page in inches.
+        marginRight:
+          type: number
+          example: 0
+          default: 1
+          description: Right margin for the page in inches.
+        paperWidth:
+          type: number
+          example: 8.27
+          description: >-
+            Paper width to be used while rendering the PDF. The default page
+            size is A4.
+        paperHeight:
+          type: number
+          example: 11.69
+          description: >-
+            Paper height to be used while rendering the PDF. The default page
+            size is A4.
+        landscape:
+          type: boolean
+          example: true
+          default: false
+          description: >-
+            The default orientation for rendering the page is "portrait" mode.
+            By sending "landscape" parameter, you can ask the output to be
+            landscape.
+        resultFilename:
+          type: string
+          example: output.pdf
+          description: >-
+            If provided, the API will return the resulting PDF file with the
+            given filename. Otherwise a random filename is used.
+      required:
+        - files
+    MarkdownConvertRequestBody:
+      title: Markdown Conversion Request Body
+      type: object
+      properties:
+        files:
+          type: array
+          description: >-
+            List of HTML files to be converted to PDF. An `index.html` file is
+            required, and any other resources that are referenced through the
+            HTML file must be included as well. All the referenced files must be
+            on the same level as the `index.html` file.
+          items:
+            type: string
+            format: binary
+        marginTop:
+          type: number
+          example: 0
+          default: 1
+          description: Top margin for the page in inches.
+        marginBottom:
+          type: number
+          example: 0
+          default: 1
+          description: Bottom margin for the page in inches.
+        marginLeft:
+          type: number
+          example: 0
+          default: 1
+          description: Left margin for the page in inches.
+        marginRight:
+          type: number
+          example: 0
+          default: 1
+          description: Right margin for the page in inches.
+        paperWidth:
+          type: number
+          example: 8.27
+          description: >-
+            Paper width to be used while rendering the PDF. The default page
+            size is A4.
+        paperHeight:
+          type: number
+          example: 11.69
+          description: >-
+            Paper height to be used while rendering the PDF. The default page
+            size is A4.
+        landscape:
+          type: boolean
+          example: true
+          default: false
+          description: >-
+            The default orientation for rendering the page is "portrait" mode.
+            By sending "landscape" parameter, you can ask the output to be
+            landscape.
+        resultFilename:
+          type: string
+          example: output.pdf
+          description: >-
+            If provided, the API will return the resulting PDF file with the
+            given filename. Otherwise a random filename is used.
+      required:
+        - files
+    URLConvertRequestBody:
+      title: URL Conversion Request Body
+      type: object
+      properties:
+        remoteURL:
+          type: string
+          example: 'https://google.com'
+        marginTop:
+          type: number
+          example: 0
+          default: 1
+          description: Top margin for the page in inches.
+        marginBottom:
+          type: number
+          example: 0
+          default: 1
+          description: Bottom margin for the page in inches.
+        marginLeft:
+          type: number
+          example: 0
+          default: 1
+          description: Left margin for the page in inches.
+        marginRight:
+          type: number
+          example: 0
+          default: 1
+          description: Right margin for the page in inches.
+        paperWidth:
+          type: number
+          example: 8.27
+          description: >-
+            Paper width to be used while rendering the PDF. The default page
+            size is A4.
+        paperHeight:
+          type: number
+          example: 11.69
+          description: >-
+            Paper height to be used while rendering the PDF. The default page
+            size is A4.
+        landscape:
+          type: boolean
+          example: true
+          default: false
+          description: >-
+            The default orientation for rendering the page is "portrait" mode.
+            By sending "landscape" parameter, you can ask the output to be
+            landscape.
+        resultFilename:
+          type: string
+          example: output.pdf
+          description: >-
+            If provided, the API will return the resulting PDF file with the
+            given filename. Otherwise a random filename is used.
+      required:
+        - remoteURL
+    OfficeConvertRequestBody:
+      title: Office Conversion Request Body
+      type: object
+      properties:
+        files:
+          type: array
+          description: >-
+            List of HTML files to be converted to PDF. An `index.html` file is
+            required, and any other resources that are referenced through the
+            HTML file must be included as well. All the referenced files must be
+            on the same level as the `index.html` file.
+          items:
+            type: string
+            format: binary
+        pageRanges:
+          type: string
+          example: 1-3
+          description: >-
+            The page ranges to be converted to PDF for the incoming Office
+            documents. **If there are multiple files sent to the API, this page
+            range will apply to all of the documents**.
+        landscape:
+          type: boolean
+          example: true
+          default: false
+          description: >-
+            The default orientation for rendering the page is "portrait" mode.
+            By sending "landscape" parameter, you can ask the output to be
+            landscape.
+        resultFilename:
+          type: string
+          example: output.pdf
+          description: >-
+            If provided, the API will return the resulting PDF file with the
+            given filename. Otherwise a random filename is used.
+      required:
+        - files
+    MergeFilesRequestBody:
+      title: Merge Files Request Body
+      type: object
+      properties:
+        files:
+          type: array
+          description: >-
+            List of HTML files to be converted to PDF. An `index.html` file is
+            required, and any other resources that are referenced through the
+            HTML file must be included as well. All the referenced files must be
+            on the same level as the `index.html` file.
+          items:
+            type: string
+            format: binary
+        resultFilename:
+          type: string
+          example: output.pdf
+          description: >-
+            If provided, the API will return the resulting PDF file with the
+            given filename. Otherwise a random filename is used.
+      required:
+        - files
+  securitySchemes: {}
+  responses:
+    SuccessfulPDF:
+      description: Resulting PDF file from the conversion.
+      content:
+        application/pdf:
+          schema:
+            type: string
+            format: binary


### PR DESCRIPTION
Hi there,

I saw in one of the issues that contributions regarding OpenAPI docs would be welcome, so I went ahead and created one. There are things missing here and there, such as contact information, but I believe this may provide us a basis to improve upon.

You can see the rendered version by copying and pasting the YAML into [Swagger Editor](https://editor.swagger.io/#). It roughly looks like as follows:
![image](https://user-images.githubusercontent.com/16530606/99293291-bdab3a00-2842-11eb-9e22-2dc85bedb68c.png)

I tried to copy the examples and definitions from the existing documentation for consistency.