### PR TITLE
Upgrade PDFtk

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -58,7 +58,10 @@ RUN curl -Ls $UNO_URL -o /usr/bin/unoconv &&\
 # | https://github.com/thecodingmachine/gotenberg/issues/29
 # |
 
-RUN apt-get -y install pdftk
+ARG PDFTK_VERSION=924565150
+
+RUN wget -O /usr/bin/pdftk "https://gitlab.com/pdftk-java/pdftk/-/jobs/${PDFTK_VERSION}/artifacts/raw/build/native-image/pdftk" \
+    && chmod a+x /usr/bin/pdftk
 
 # |--------------------------------------------------------------------------
 # | Fonts


### PR DESCRIPTION
**Summary**

We are seeing an issue when merging PDFs with Gotenberg, with exceptions coming from `pdftk`.

```
java.lang.ClassCastException: class pdftk.com.lowagie.text.pdf.PRIndirectReference cannot be cast to class pdftk.com.lowagie.text.pdf.PdfName (pdftk.com.lowagie.text.pdf.PRIndirectReference and pdftk.com.lowagie.text.pdf.PdfName are in unnamed module of loader 'app'
```

These issues do not seem to be present in the latest version of `pdftk`. The version currently being used, is quite old, so this patch updates it to the latest version.

**Checklist**

- [X] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [X] Have you lint your code locally prior to submission (`make lint`)?
- [X] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [X] Have you updated the documentation (Markdown files under `build > docs > content` and then `make doc`)?
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code