### PR TITLE
Reduce the docker image size

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -7,7 +7,7 @@ FROM debian:buster-slim
 # | Libraries used in the build process of this image.
 # |
 RUN apt-get update &&\
-    apt-get --no-install-recommends install -y ca-certificates wget curl gnupg procps &&\
+    apt-get --no-install-recommends install -y ca-certificates curl gnupg procps &&\
     rm -rf /var/lib/apt/lists/*
 
 # |--------------------------------------------------------------------------
@@ -24,8 +24,7 @@ RUN apt-get update &&\
 # |
 # | Installs Chrome.
 # |
-
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
+RUN curl https://dl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&\
     apt-get update &&\
     apt-get install --no-install-recommends -y --allow-unauthenticated google-chrome-stable &&\
@@ -69,7 +68,7 @@ RUN curl -Ls $UNO_URL -o /usr/bin/unoconv &&\
 
 ARG PDFTK_VERSION=924565150
 
-RUN wget -O /usr/bin/pdftk "https://gitlab.com/pdftk-java/pdftk/-/jobs/${PDFTK_VERSION}/artifacts/raw/build/native-image/pdftk" \
+RUN curl -o /usr/bin/pdftk "https://gitlab.com/pdftk-java/pdftk/-/jobs/${PDFTK_VERSION}/artifacts/raw/build/native-image/pdftk" \
     && chmod a+x /usr/bin/pdftk
 
 # |--------------------------------------------------------------------------

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -9,7 +9,7 @@ FROM debian:buster-slim
 
 RUN echo "deb http://httpredir.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list &&\
     apt-get update &&\
-    apt-get install -y curl wget gnupg ttf-mscorefonts-installer procps
+    apt-get install --no-install-recommends -y curl wget gnupg ttf-mscorefonts-installer procps
 
 # |--------------------------------------------------------------------------
 # | Chrome
@@ -21,7 +21,7 @@ RUN echo "deb http://httpredir.debian.org/debian/ buster main contrib non-free" 
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&\
     apt-get update &&\
-    apt-get -y --allow-unauthenticated install google-chrome-stable
+    apt-get install --no-install-recommends -y --allow-unauthenticated google-chrome-stable
 
 # |--------------------------------------------------------------------------
 # | LibreOffice
@@ -34,7 +34,7 @@ RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&\ 
     echo "deb http://httpredir.debian.org/debian/ buster-backports main contrib non-free" >> /etc/apt/sources.list &&\
     apt-get update &&\
-    apt-get -t buster-backports -y install libreoffice
+    apt-get --no-install-recommends -t buster-backports -y install libreoffice
 
 # |--------------------------------------------------------------------------
 # | Unoconv
@@ -74,7 +74,8 @@ RUN wget -O /usr/bin/pdftk "https://gitlab.com/pdftk-java/pdftk/-/jobs/${PDFTK_V
 # Credits: 
 # https://github.com/arachnys/athenapdf/blob/master/cli/Dockerfile
 # https://help.accusoft.com/PrizmDoc/v12.1/HTML/Installing_Asian_Fonts_on_Ubuntu_and_Debian.html
-RUN apt-get install -y \
+RUN apt-get update &&\
+    apt-get install --no-install-recommends -y \
     culmus \
     fonts-beng \
     fonts-hosny-amiri \

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -9,7 +9,8 @@ FROM debian:buster-slim
 
 RUN echo "deb http://httpredir.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list &&\
     apt-get update &&\
-    apt-get install --no-install-recommends -y curl wget gnupg ttf-mscorefonts-installer procps
+    apt-get install --no-install-recommends -y curl wget gnupg ttf-mscorefonts-installer procps &&\
+    rm -rf /var/lib/apt/lists/*
 
 # |--------------------------------------------------------------------------
 # | Chrome
@@ -21,7 +22,8 @@ RUN echo "deb http://httpredir.debian.org/debian/ buster main contrib non-free" 
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&\
     apt-get update &&\
-    apt-get install --no-install-recommends -y --allow-unauthenticated google-chrome-stable
+    apt-get install --no-install-recommends -y --allow-unauthenticated google-chrome-stable &&\
+    rm -rf /var/lib/apt/lists/*
 
 # |--------------------------------------------------------------------------
 # | LibreOffice
@@ -34,7 +36,8 @@ RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&\ 
     echo "deb http://httpredir.debian.org/debian/ buster-backports main contrib non-free" >> /etc/apt/sources.list &&\
     apt-get update &&\
-    apt-get --no-install-recommends -t buster-backports -y install libreoffice
+    apt-get --no-install-recommends -t buster-backports -y install libreoffice &&\
+    rm -rf /var/lib/apt/lists/*
 
 # |--------------------------------------------------------------------------
 # | Unoconv
@@ -95,7 +98,8 @@ RUN apt-get update &&\
     fonts-arphic-uming \
     fonts-ipafont-mincho \
     fonts-ipafont-gothic \
-    fonts-unfonts-core
+    fonts-unfonts-core &&\
+    rm -rf /var/lib/apt/lists/*
 
 COPY build/base/fonts/* /usr/local/share/fonts/
 COPY build/base/fonts.conf /etc/fonts/conf.d/100-gotenberg.conf

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -6,10 +6,16 @@ FROM debian:buster-slim
 # |
 # | Libraries used in the build process of this image.
 # |
+RUN apt-get update &&\
+    apt-get --no-install-recommends install -y ca-certificates wget curl gnupg procps &&\
+    rm -rf /var/lib/apt/lists/*
 
-RUN echo "deb http://httpredir.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list &&\
-    apt-get update &&\
-    apt-get install --no-install-recommends -y curl wget gnupg ttf-mscorefonts-installer procps &&\
+# |--------------------------------------------------------------------------
+# | Microsoft font installer
+# |--------------------------------------------------------------------------
+RUN apt-get update &&\
+    curl -o ./ttf-mscorefonts-installer_3.8_all.deb http://httpredir.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.8_all.deb &&\
+    apt --no-install-recommends install -y ./ttf-mscorefonts-installer_3.8_all.deb && rm ./ttf-mscorefonts-installer_3.8_all.deb &&\
     rm -rf /var/lib/apt/lists/*
 
 # |--------------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Attempt to reduce the size of the final docker image by implementing best practises

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

The image is large, which takes along time to pull, both locally and in CI.
Reducing the image size would speed up all workflows.

before:
```
thecodingmachine/gotenberg   snapshot          6a331ede6633   58 seconds ago   2.09GB
thecodingmachine/gotenberg   workspace         4e672515939a   35 minutes ago   2.57GB
thecodingmachine/gotenberg   base              0283fe0a2587   4 days ago       2.07GB
```

after:
```
thecodingmachine/gotenberg   snapshot          5fb3376d929d   6 minutes ago    1.07GB
thecodingmachine/gotenberg   workspace         ea1fda548f72   56 minutes ago   1.62GB
thecodingmachine/gotenberg   base              beb19c268974   58 minutes ago   1.05GB
```

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Existing tests should pass

<!-- Make sure tests pass on Travis. -->


**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] Have you updated the documentation (Markdown files under `build > docs > content` and then `make doc`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
