### PR TITLE
Feature add arm support and use chromium

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:buster-slim
+ARG ARCH=
+FROM ${ARCH}debian:buster-slim
 
 # |--------------------------------------------------------------------------
 # | Common libraries
@@ -19,15 +20,13 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/*
 
 # |--------------------------------------------------------------------------
-# | Chrome
+# | Chromium
 # |--------------------------------------------------------------------------
 # |
-# | Installs Chrome.
+# | Installs Chromium as Chrome replacement
 # |
-RUN curl https://dl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
-    echo "deb https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&\
-    apt-get update &&\
-    apt-get install --no-install-recommends -y --allow-unauthenticated google-chrome-stable &&\
+RUN apt-get update &&\
+    apt-get --no-install-recommends install -y chromium &&\
     rm -rf /var/lib/apt/lists/*
 
 # |--------------------------------------------------------------------------

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -4,13 +4,12 @@
 # |
 # | Builds Gotenberg binary.
 # |
-
-FROM thecodingmachine/gotenberg:workspace AS workspace
+ARG ARCH=
+FROM ${ARCH}thecodingmachine/gotenberg:workspace AS workspace
 
 ARG VERSION
 
 ENV GOOS=linux \
-    GOARCH=amd64 \
     CGO_ENABLED=0
 
 # Define our workding outside of $GOPATH (we're using go modules).
@@ -42,7 +41,7 @@ LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>"
 
 ARG TINI_VERSION
 
-ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static /tini
+RUN wget https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-$( dpkg --print-architecture ) -O /tini
 RUN chmod +x /tini
 ENTRYPOINT [ "/tini", "--" ]
 

--- a/build/workspace/Dockerfile
+++ b/build/workspace/Dockerfile
@@ -1,6 +1,6 @@
 ARG GOLANG_VERSION
-
-FROM golang:${GOLANG_VERSION}-stretch as golang
+ARG ARCH=
+FROM ${ARCH}golang:${GOLANG_VERSION}-stretch as golang
 
 FROM thecodingmachine/gotenberg:base
 

--- a/internal/pkg/chrome/chrome.go
+++ b/internal/pkg/chrome/chrome.go
@@ -45,7 +45,7 @@ func Start(logger xlog.Logger, ignoreCertificateErrors bool) error {
 
 func cmd(logger xlog.Logger, ignoreCertificateErrors bool) (*exec.Cmd, error) {
 	const op string = "chrome.cmd"
-	binary := "google-chrome-stable"
+	binary := "chromium"
 	args := []string{
 		"--no-sandbox",
 		"--headless",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -20,7 +20,9 @@ if [ $VERSION_LENGTH -ne 3 ]; then
     exit 1
 fi
 
-docker build \
+docker buildx build \
+    --platform linux/arm/v7,linux/arm64/v8,linux/amd64
+    --push
     --build-arg VERSION=${VERSION} \
     --build-arg TINI_VERSION=${TINI_VERSION} \
     -t ${DOCKER_REGISTRY}/gotenberg:latest \
@@ -29,7 +31,3 @@ docker build \
     -t ${DOCKER_REGISTRY}/gotenberg:${SEMVER[0]}.${SEMVER[1]}.${SEMVER[2]} \
     -f build/package/Dockerfile .
 
-docker push "${DOCKER_REGISTRY}/gotenberg:latest"
-docker push "${DOCKER_REGISTRY}/gotenberg:${SEMVER[0]}"
-docker push "${DOCKER_REGISTRY}/gotenberg:${SEMVER[0]}.${SEMVER[1]}"
-docker push "${DOCKER_REGISTRY}/gotenberg:${SEMVER[0]}.${SEMVER[1]}.${SEMVER[2]}"


### PR DESCRIPTION
This allows to build and run gotenberg on a raspbarry 4b.

We are using chromium as there is no arm build of chrome.

The tiny executable needs to be changed to the version that is
compatible with the correct architecture.

Also preparing for multi-architecture building of the docker images in
the publish script.

We removed the crosscompiling enviornment variables of go, as they are
preventing a compiling for arm and they will be set automatically.

fixes https://github.com/thecodingmachine/gotenberg/issues/213

**Test plan**
Please check if this changes are not braking anything. I have tested the code only on an Raspbarry Pi v4 
