### PR TITLE
Add tags on openapi.yaml endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -141,7 +141,7 @@ paths:
   /convert/markdown:
     post:
       tags:
-        - Html2Pdf
+        - Gotenberg
       summary: Convert a Markdown file to PDF
       description: >-
         Send an HTML file called `index.html` as a multipart form request and
@@ -311,7 +311,6 @@ paths:
       tags:
         - Gotenberg
       summary: Your GET endpoint
-      tags: []
       responses:
         '200':
           description: The API is working fine.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16,6 +16,8 @@ servers:
 paths:
   /convert/html:
     post:
+      tags:
+        - Gotenberg
       summary: Convert a given HTML file to PDF
       description: >-
         Send an HTML file called `index.html` as a multipart form request, and
@@ -114,6 +116,8 @@ paths:
           $ref: '#/components/responses/SuccessfulPDF'
   /convert/url:
     post:
+      tags:
+        - Gotenberg
       summary: Convert the contents of a given URL to PDF
       description: >-
         Send a remote URL in your API request via the `remoteURL` parameter, and
@@ -136,6 +140,8 @@ paths:
           $ref: '#/components/responses/SuccessfulPDF'
   /convert/markdown:
     post:
+      tags:
+        - Html2Pdf
       summary: Convert a Markdown file to PDF
       description: >-
         Send an HTML file called `index.html` as a multipart form request and
@@ -195,6 +201,8 @@ paths:
           $ref: '#/components/responses/SuccessfulPDF'
   /convert/office:
     post:
+      tags:
+        - Gotenberg
       summary: Convert an Office document to PDF
       description: >-
         Send one or more Office documents and get the resulting PDF file by
@@ -257,6 +265,8 @@ paths:
                 properties: {}
   /convert/merge:
     post:
+      tags:
+        - Gotenberg
       summary: Merge multiple PDFs into a single PDF
       description: >-
         You can send multiple PDF files to this endpoint, the API will merge
@@ -298,6 +308,8 @@ paths:
           $ref: '#/components/responses/SuccessfulPDF'
   /ping:
     get:
+      tags:
+        - Gotenberg
       summary: Your GET endpoint
       tags: []
       responses:


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **features** - this is actually a minor fix (nice to have)

* [ ] On generating the Java client using openapi.yaml the tag will be used to name the Java class which will provide the client implementation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

I wanna use gotenberg as a docker service and make requests from my spring-boot app. I didn't want to write an http client on my own as I saw that you provide an openapi.yaml spec. Thus, I'm using an openapi generator in my application, feeding your app's openapi spec and voila: The java client that I could already use gets automatically generated. The drawback was that the endpoints in the openapi spec didn't provide any `tags` and then the default name for the Java client would have been `DefaultApi`.. that's not intuitive at all. (see the snapshots below)

**BEFORE**
![image](https://user-images.githubusercontent.com/5001967/125122294-e6e44780-e0fd-11eb-9a66-e77adb33bd6e.png)

**AFTER**
![image](https://user-images.githubusercontent.com/5001967/125122365-fd8a9e80-e0fd-11eb-9515-f42a5bf3b533.png)


